### PR TITLE
Adding OpenSUSE Leap 42.1

### DIFF
--- a/src/opensuse.ipxe
+++ b/src/opensuse.ipxe
@@ -1,9 +1,10 @@
 #!ipxe
 
-# Novell OpenSUSE Operating System
+# OpenSUSE Operating System
 # http://opensuse.org
 
 menu openSUSE ${arch}
+item 42.1 openSUSE 42.1 (leap)
 item 13.2 openSUSE 13.2
 item 13.1 openSUSE 13.1
 item 12.3 openSUSE 12.3
@@ -12,8 +13,8 @@ item 11.4 openSUSE 11.4
 item factory-tested openSUSE factory-tested
 item tumbleweed openSUSE tumbleweed
 choose version || goto opensuse_exit
-
 set dir opensuse/distribution/${version}/repo/oss
+iseq ${version} 42.1 && set dir opensuse/distribution/leap/42.1/repo/oss && set arch x86_64 ||
 iseq ${version} tumbleweed && set mirror download.opensuse.org && set dir ${version}/repo/oss ||
 iseq ${version} factory-tested && set dir ${version}/repo/oss/ ||
 


### PR DESCRIPTION
Also only use and only use x86_64 as i686 versions are no longer being released.
