### PR TITLE
Fix a faulty url to iPXE inside the docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ You can remote attach the ISO to servers, set it up as a rescue option in Grub, 
 
 ### Getting started
 
-Download the bootloader of your choice from the links above and add it to your favorite virtualization tool to start testing out netboot.xyz.  These are precompiled versions of the latest version of [iPXE](http://https://github.com/ipxe/ipxe) that will chainload you to [http://boot.netboot.xyz](http://boot.netboot.xyz).  There are two versions of each, one if you have DHCP on your network, and one if you have to set a static IP before connecting outside of your network.
+Download the bootloader of your choice from the links above and add it to your favorite virtualization tool to start testing out netboot.xyz.  These are precompiled versions of the latest version of [iPXE](https://github.com/ipxe/ipxe) that will chainload you to [http://boot.netboot.xyz](http://boot.netboot.xyz).  There are two versions of each, one if you have DHCP on your network, and one if you have to set a static IP before connecting outside of your network.
 
 If you already have iPXE up and running on the network, you can hit netboot.xyz at anytime by typing:
 


### PR DESCRIPTION
Fixed a faulty URL pointing to the iPXE project on GitHub.
