### PR TITLE
Download cdXY.iso instead of installXY.iso

### DIFF
--- a/src/openbsd.ipxe
+++ b/src/openbsd.ipxe
@@ -21,7 +21,7 @@ set openbsd_arch amd64
 goto boot_openbsd
 
 :boot_openbsd
-set src http://ftp.openbsd.org/pub/OpenBSD/${ver}/${openbsd_arch}/install${image_ver}.iso
+set src http://ftp.openbsd.org/pub/OpenBSD/${ver}/${openbsd_arch}/cd${image_ver}.iso
 imgfree
 initrd ${src}
 chain ${memdisk} iso raw


### PR DESCRIPTION
Since the iso image is not available from the installer, there's no point in downloading 200+ MB installXY.iso when we can get the same install environment from <10MB cdXY.iso
