### PR TITLE
Add the ability to utilize custom menus (experimental)

### DIFF
--- a/src/menu.ipxe
+++ b/src/menu.ipxe
@@ -1,7 +1,6 @@
 #!ipxe
 
 :start
-
 chain --autofree boot.cfg ||
 
 iseq ${cls} serial && goto ignore_cls ||
@@ -31,6 +30,8 @@ item --gap Installers:
 item linux ${space} Linux Installers
 item bsd ${space} BSD Installers
 item freedos ${space} FreeDOS Installers
+isset ${github_user} && item --gap Custom Menu: ||
+isset ${github_user} && item nbxyz-custom ${space} ${github_user}'s Custom Menu ||
 item --gap Tools:
 item utils ${space} Utilities
 item shell ${space} iPXE shell
@@ -102,6 +103,10 @@ goto main_menu
 
 :hypervisors
 chain hypervisors.ipxe
+goto main_menu
+
+:nbxyz-custom
+chain https://raw.githubusercontent.com/${github_user}/netboot.xyz-custom/master/custom.ipxe || 
 goto main_menu
 
 :utils

--- a/src/utils.ipxe
+++ b/src/utils.ipxe
@@ -14,6 +14,7 @@ item partition_wizard ${space} Partition Wizard
 item pogostick ${space} Pogostick - Offline Windows Password and Registry Editor
 item supergrub ${space} Super Grub2 Disk
 item --gap netboot.xyz tools:
+item nbxyz-custom ${space} Set Github User [user: ${github_user}]
 item testdistro ${space} Test Distribution ISO
 item testpr ${space} Test netboot.xyz branch
 choose --default ${menu} menu || goto utils_exit
@@ -72,6 +73,16 @@ goto utils_exit
 :memtest_501
 chain https://boot.netboot.xyz/utils/memtest86-5.01.bin && goto main_menu ||
 goto utils_exit
+
+:nbxyz-custom
+echo EXPERIMENTAL
+echo 
+echo Make sure you have a fork of https://github.com/antonym/netboot.xyz-custom.
+echo You can then customize your fork as needed and set up your own custom options.
+echo Once your username is set, a custom option will appear on the main menu.
+echo
+echo -n Please enter your Github username: ${} && read github_user
+goto utils_exit 
 
 :netbootcd
 kernel http://netbootcd.us/downloads/6.4.1/vmlinuz


### PR DESCRIPTION
Used in conjunction with https://github.com/antonym/netboot.xyz-custom users can fork the netboot.xyz-custom project and create their own menus from scratch.  Setting the github_user variable from the Utility menu will enable the custom option in the main menu.  Eventually the github user could be compiled in the iPXE image to avoid having to enter in the github_user every time.
