### PR TITLE
Add MirBSD (MirOS BSD-current/i386 install/rescue boot)

### DIFF
--- a/src/bsd.ipxe
+++ b/src/bsd.ipxe
@@ -11,6 +11,7 @@ iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 item --gap BSD Based Operating Systems
 item freebsd ${space} FreeBSD
 item openbsd ${space} OpenBSD
+item mirbsd ${space} MirBSD (i386 only)
 
 # Options
 item --gap Options:
@@ -37,3 +38,12 @@ exit 0
 :changebits
 iseq ${arch} x86_64 && set arch i386 || set arch x86_64
 goto bsd_menu
+
+#XXX image signature verification missing, how to add?
+:mirbsd
+imgfree
+kernel https://www.mirbsd.org/MirOS/current/bsd4me.com
+module https://www.mirbsd.org/MirOS/current/bsd4me.rd
+module https://www.mirbsd.org/MirOS/webstuff/netboot.xyz/boot.cfg
+boot
+goto bsd_exit


### PR DESCRIPTION
without image signatures, for now (until someone tells me how to add them)

Note: chainloading is broken, it does load menu.ipxe from the github branch, but as soon as I enter the BSD menu I get the original from your boot server; if I go to the iPXE shell and then run `chain --autofree 
https://raw.githubusercontent.com/MirBSD/netboot.xyz/master/src/bsd.ipxe` it can be tested.
