### PR TITLE
Trying to fix path issue with windows installation

### DIFF
--- a/src/windows.ipxe
+++ b/src/windows.ipxe
@@ -51,7 +51,7 @@ iseq ${img_sigs_enabled} true && goto verify_sigs || goto skip_sigs
 :verify_sigs
 echo
 echo Checking wimboot signature...
-imgverify wimboot ${sigs}/wimboot.sig || goto error
+imgverify wimboot ${sigs}wimboot.sig || goto error
 :skip_sigs
 boot
 


### PR DESCRIPTION
This fixes the URL path that failed for me when netboot tried the following:

```
Checking wimboot signature...
http://boot.netboot.xyz/sigs//wimbooy.sig... Operation not permitted
```

Further expection showed that the url gave an error response. Removing the addition / in the URL solved the issue for me.
