### PR TITLE
Boot Ubuntu Live System via HTTP

### DIFF
--- a/src/ubuntu.ipxe
+++ b/src/ubuntu.ipxe
@@ -30,11 +30,16 @@ echo Setting mirror to ${ubuntu_mirror}
 clear ubuntu_version
 echo -n Please set enter code name of release: ${} && read ubuntu_version
 set dir ubuntu/dists/${ubuntu_version}/main/installer-${arch_a}/current/images/netboot/
+set httpboot_version NONE
 goto deb_boot_type
 
 :mirrorcfg
 set mirrorcfg mirror/suite=${ubuntu_version} mirror/country=manual mirror/http/hostname=${ubuntu_mirror} mirror/http/directory=/ubuntu
 set dir ubuntu/dists/${ubuntu_version}/main/installer-${arch_a}/current/images/netboot/
+set httpboot_version NONE
+iseq ${ubuntu_version} trusty && set httpboot_version 14.04.1 ||
+iseq ${ubuntu_version} xenial && set httpboot_version 16.04 ||
+iseq ${ubuntu_version} yakkety && set httpboot_version 16.10 ||
 
 :deb_boot_type
 menu ${os} [${ubuntu_version}] Installer
@@ -42,6 +47,7 @@ item --gap Install types
 item install ${space} Install
 item rescue ${space} Rescue Mode
 item expert ${space} Expert Install
+iseq ${httpboot_version} NONE || item httpboot ${space} Live System (via HTTPFS2)
 item preseed ${space} Specify preseed url...
 choose --default ${type} type || goto ubuntu
 echo ${cls}
@@ -79,6 +85,13 @@ imgverify initrd.gz ${sigs}${dir}/initrd.gz.sig || goto error
 echo Signatures verified!
 echo
 :skip_sigs
+boot
+
+:deb_httpboot
+imgfree
+nslookup release_host_ip releases.ubuntu.com || set release_host_ip 91.189.88.160
+kernel http://live-httpboot.sourceforge.net/ubuntu/0.2/${ubuntu_version}_${httpboot_version}_${arch_a}_vmlinuz root=/dev/nfs boot=casper hostsentry=${release_host_ip}:releases.ubuntu.com netboot=http nfsroot=http://releases.ubuntu.com/${ubuntu_version}/ubuntu-${httpboot_version}-desktop-${arch_a}.iso --
+initrd http://live-httpboot.sourceforge.net/ubuntu/0.2/${ubuntu_version}_${httpboot_version}_${arch_a}_initrd.lz
 boot
 
 :ubuntu_exit


### PR DESCRIPTION
This uses initramfs built by
<https://github.com/live-httpboot/ubuntu-live-httpboot/>, which in turn
uses httpfs2 from <http://httpfs.sourceforge.net> to mount the live ISO
via HTTP.

Kernel and Initamfs are hosted at SourceForge since iPXE does not like
downloads from GitHub.

Due to lack of support for nslookup in current netboot.xyz images, the IP
address for releases.ubuntu.com is hardcoded as a fallback if nslookup is
not available.

Httpboot images are currently only available for 14.04.1, 16.04 and 16.10
- if you need anything else, feel free to open an issue at the GitHub
project mentioned above.