### PR TITLE
Adds Live Boot Menu with Debian Live

### DIFF
--- a/src/live.ipxe
+++ b/src/live.ipxe
@@ -1,0 +1,25 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+menu Live Boot Distributions - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap Live Boot Distributions
+item livedebian ${space} Debian Live
+choose menu || goto live_exit
+echo ${cls}
+goto ${menu} ||
+iseq ${sigs_enabled} true && goto verify_sigs || goto change_menu
+
+:verify_sigs
+imgverify ${menu}.ipxe ${sigs}${menu}.ipxe.sig || goto error
+goto change_menu
+
+:change_menu
+chain ${menu}.ipxe || goto error
+goto live_menu
+
+:live_exit
+clear menu
+exit 0

--- a/src/livedebian.ipxe
+++ b/src/livedebian.ipxe
@@ -1,0 +1,43 @@
+#!ipxe
+
+# Debian Live
+# https://www.debian.org/devel/debian-live/
+
+goto ${menu}
+
+:livedebian
+set os Debian Live
+menu ${os}
+item --gap Versions
+item 8.7.1 ${space} ${os} 8.7.1
+choose livedebian_version || goto livedebian_exit
+
+:livedebian_flavor
+menu ${os} ${livedebian_version}
+item --gap Flavors
+item cinnamon ${livedebian_version} Cinnamon
+item gnome ${livedebian_version} Gnome
+item kde ${livedebian_version} KDE
+item lxde ${livedebian_version} LXDE
+item mate ${livedebian_version} MATE
+item standard ${livedebian_version} Standard
+item xfce ${livedebian_version} XFCE
+choose --default ${type} flavor || goto livedebian
+echo ${cls}
+goto livedebian_boot
+
+:livedebian_boot
+set webboot_host mirrors.kernel.org
+set livedebian_url http://${webboot_host}/debian-cd/${livedebian_version}-live/amd64/webboot/debian-live-${livedebian_version}-amd64-${flavor}-desktop
+imgfree
+kernel ${livedebian_url}.vmlinuz boot=live config hooks=filesystem username=live noeject fetch=${livedebian_url}.squashfs initrd=debian-live-${livedebian_version}-amd64-${flavor}-desktop.initrd.img
+module ${livedebian_url}.initrd.img
+# used to resolve DNS
+module http://${boot_domain}/live-helpers/debian/libresolv.so.2 /lib/libresolv.so.2
+module http://${boot_domain}/live-helpers/debian/libnss_dns.so.2 /lib/libnss_dns.so.2
+boot
+goto livedebian_exit
+
+:livedebian_exit
+clear menu
+exit 0

--- a/src/menu.ipxe
+++ b/src/menu.ipxe
@@ -45,6 +45,7 @@ item linux ${space} Linux Installs
 item bsd ${space} BSD Installs
 item freedos ${space} FreeDOS
 item hypervisor ${space} Hypervisor Installs
+item live ${space} Live Boot
 item security ${space} Security Related
 item windows ${space} Windows
 item --gap Tools:


### PR DESCRIPTION
Adds Live Boot Menu and Debian Live webboot images, uses user: live, password: live to log in on console.  Useful for quick access to a GUI.