### PR TITLE
Add support for Google Compute Cloud

### DIFF
--- a/docs/usage-gce.md
+++ b/docs/usage-gce.md
@@ -1,0 +1,51 @@
+# Google Compute Engine (GCE)
+
+**Experimental, currently doesn't work on any images that utilize memdisk as console output cannot be altered.**
+
+*Note: Functionality will be limited as the console is Serial Over Lan.  Distros that utilize memdisk may not provide output while other distros that are retrieved via kernel allow for altering of the console settings during load.  This includes most of the utility tools.  I'll probably look at filtering out options that don't work in the future.  Console may work during the install but may stop working on first boot if it's not set during the install.*
+
+### Create a Bucket
+
+Set a name for your bucket and select the regional storage class.
+
+Upload the netboot.xyz-gce image from this [link](https://boot.netboot.xyz/ipxe/netboot.xyz-gce.tar.gz) to the root of your bucket.
+
+    gsutil cp $tmp/$image_name.tar.gz gs://$gs_bucket
+
+### Create an image
+
+Using the gcloud utility or the Google Cloud Shell, create an image from the iPXE disk you uploaded in the previous step:
+
+    gcloud compute images create $image_name --source-uri gs://$gs_bucket/$image_name.tar.gz
+
+### Boot an instance
+
+Start an instance from the image you created, make sure to enable the serial-port:
+
+    gcloud compute instances create $instance_name --image $image_name --metadata serial-port-enable=1
+
+### Connect to the Instance over Serial Console
+
+    gcloud beta compute connect-to-serial-port $instance_name
+
+From here you should see the netboot.xyz menu and that's probably all you'll be able to do at this point. :)
+
+### Configuring the Instance
+
+In the event DHCP does not work, you'll need to set the static IP address during install time.  You can view this by going into instance details in the console, and clicking on default under network.  You'll need to set the internal IP of the instance along with the subnet and gateway on that page.
+
+### Notes
+
+Here are some notes on how the iPXE image is created in case you want to play around with vanilla iPXE in GCE.
+
+See the iPXE commit [here](https://github.com/ipxe/ipxe/commit/de85336abb7861e4ea4df2e296eb33d179c7c9bd) for more info of GCE support in iPXE.
+
+To create a usable image for GCE:
+
+    make bin/ipxe.usb CONFIG=cloud EMBED=$tmp/main.ipxe
+    cp -f bin/ipxe.usb $tmp/disk.raw
+    ( cd $tmp; tar Sczvf $image_name.tar.gz disk.raw )
+
+To get the installers to work to output serial, when the GCE disk is detected, the console on the kernel command line is set to:
+
+    console=ttyS0,115200n8

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ pages:
     - 'VMware': 'boot-vmware.md'
 - Provider Usage:
     - 'Digital Ocean': 'usage-digitalocean.md'
+    - 'Google Compute Engine': 'usage-gce.md'
     - 'Rackspace': 'usage-rackspace.md'
     - 'Vultr': 'usage-vultr.md'
 - FAQ: 'faq.md'

--- a/src/archlinux.ipxe
+++ b/src/archlinux.ipxe
@@ -21,7 +21,7 @@ goto boot
 imgfree
 iseq ${arch} i386 && set bootarch i686 || set bootarch x86_64
 set dir archlinux/iso/${arch_version}/arch/boot
-set params initrd=archiso.img archiso_http_srv=http://${mirror}/archlinux/iso/${arch_version}/ archisobasedir=arch verify=y ip=dhcp net.ifnames=0
+set params initrd=archiso.img archiso_http_srv=http://${mirror}/archlinux/iso/${arch_version}/ archisobasedir=arch verify=y ip=dhcp net.ifnames=0 ${console}
 kernel http://${mirror}/${dir}/${bootarch}/vmlinuz ${params}
 initrd http://${mirror}/${dir}/${bootarch}/archiso.img
 echo

--- a/src/centos.ipxe
+++ b/src/centos.ipxe
@@ -58,7 +58,7 @@ goto boottype
 
 :bootos_images
 imgfree
-kernel http://${mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${netcfg}
+kernel http://${mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${netcfg} ${console}
 initrd http://${mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/src/coreos.ipxe
+++ b/src/coreos.ipxe
@@ -27,7 +27,7 @@ goto coreos_exit
 :alpha
 set release ${menu}
 set base-url http://${release}.release.core-os.net/amd64-usr/current
-kernel ${base-url}/coreos_production_pxe.vmlinuz ${coreos_params} console=tty0 console=ttyS0 coreos.autologin=tty1 coreos.autologin=ttyS0
+kernel ${base-url}/coreos_production_pxe.vmlinuz ${coreos_params} ${console} coreos.autologin=tty1 coreos.autologin=ttyS0
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot
 goto coreos_exit

--- a/src/debian.ipxe
+++ b/src/debian.ipxe
@@ -75,7 +75,7 @@ goto deb_boot
 :deb_boot
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel http://${debian_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet ${params} initrd=initrd.gz
+kernel http://${debian_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
 initrd http://${debian_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/src/fedora.ipxe
+++ b/src/fedora.ipxe
@@ -51,7 +51,7 @@ goto boot
 
 :boot
 imgfree
-kernel http://${mirror}/${dir}/images/pxeboot/vmlinuz repo=http://${mirror}/${dir} ${params}
+kernel http://${mirror}/${dir}/images/pxeboot/vmlinuz repo=http://${mirror}/${dir} ${params} ${console}
 initrd http://${mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/src/gentoo.ipxe
+++ b/src/gentoo.ipxe
@@ -20,7 +20,7 @@ goto ${gentoo_version}
 set gentoopath https://sourceforge.net/projects/netboot-xyz/files/distros/gentoo/amd64/20160204
 echo Please note the gentoo ISO has been regenerated to work with iPXE
 echo using the method here: http://blog.dastrup.com/?p=12
-kernel --name gentoo-kernel ${gentoopath}/kernel/download root=/dev/ram0 init=/linuxrc loop=/image.squashfs looptype=squashfs cdroot=1 real_root=/
+kernel --name gentoo-kernel ${gentoopath}/kernel/download root=/dev/ram0 init=/linuxrc loop=/image.squashfs looptype=squashfs cdroot=1 real_root=/ ${console}
 initrd --name gentoo-initrd.img ${gentoopath}/initrd/download
 boot
 goto gentoo

--- a/src/kali.ipxe
+++ b/src/kali.ipxe
@@ -26,7 +26,7 @@ goto deb_boot
 
 :deb_boot
 imgfree
-kernel http://repo.kali.org/${dir}/linux vga=788 -- quiet
+kernel http://repo.kali.org/${dir}/linux vga=788 ${console} -- quiet
 initrd http://repo.kali.org/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/src/livedebian.ipxe
+++ b/src/livedebian.ipxe
@@ -30,7 +30,7 @@ goto livedebian_boot
 set webboot_host mirrors.kernel.org
 set livedebian_url http://${webboot_host}/debian-cd/${livedebian_version}-live/amd64/webboot/debian-live-${livedebian_version}-amd64-${flavor}-desktop
 imgfree
-kernel ${livedebian_url}.vmlinuz boot=live config hooks=filesystem username=live noeject fetch=${livedebian_url}.squashfs initrd=debian-live-${livedebian_version}-amd64-${flavor}-desktop.initrd.img
+kernel ${livedebian_url}.vmlinuz boot=live config hooks=filesystem username=live noeject ${console} fetch=${livedebian_url}.squashfs initrd=debian-live-${livedebian_version}-amd64-${flavor}-desktop.initrd.img
 module ${livedebian_url}.initrd.img
 # used to resolve DNS
 module http://${boot_domain}/live-helpers/debian/libresolv.so.2 /lib/libresolv.so.2

--- a/src/mageia.ipxe
+++ b/src/mageia.ipxe
@@ -23,7 +23,7 @@ set automatic method:http,network:dhcp,server:${server},directory:/${dir}
 imgfree
 kernel ${mirror}/${dir}/vmlinuz
 initrd ${mirror}/${dir}/all.rdz
-imgargs vmlinuz automatic=${automatic} vga=788 splash=silent
+imgargs vmlinuz automatic=${automatic} vga=788 splash=silent ${console}
 echo
 echo MD5sums:
 md5sum vmlinuz all.rdz

--- a/src/menu.ipxe
+++ b/src/menu.ipxe
@@ -2,11 +2,15 @@
 
 :start
 chain --autofree boot.cfg ||
-
 iseq ${cls} serial && goto ignore_cls ||
 set cls:hex 1b:5b:4a  # ANSI clear screen sequence - "^[[J"
 set cls ${cls:string}
 :ignore_cls
+iseq ${ipxe_cloud_config} gce && goto cloud_config || goto version_check
+
+:cloud_config
+set console console=ttyS0,115200n8
+goto version_check
 
 :version_check
 set latest_version 1.04

--- a/src/opensuse.ipxe
+++ b/src/opensuse.ipxe
@@ -20,7 +20,7 @@ iseq ${version} tumbleweed && set mirror download.opensuse.org && set dir ${vers
 imgfree
 kernel http://${mirror}/${dir}/boot/${arch}/loader/linux
 initrd http://${mirror}/${dir}/boot/${arch}/loader/initrd
-imgargs linux netsetup=dhcp install=http://${mirror}/${dir} ${params} ${netcfg}
+imgargs linux netsetup=dhcp install=http://${mirror}/${dir} ${params} ${netcfg} ${console}
 echo
 echo MD5sums:
 md5sum linux initrd

--- a/src/scientific.ipxe
+++ b/src/scientific.ipxe
@@ -47,7 +47,7 @@ goto bootos_images
 
 :bootos_images
 imgfree
-kernel http://ftp1.scientificlinux.org/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${netcfg}
+kernel http://ftp1.scientificlinux.org/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${netcfg} ${console}
 initrd http://ftp1.scientificlinux.org/${dir}/images/pxeboot/initrd.img
 boot
 goto linux_menu

--- a/src/slackware.ipxe
+++ b/src/slackware.ipxe
@@ -26,6 +26,6 @@ goto boot
 imgfree
 kernel http://${mirror}/${dir}/kernels/huge.s/bzImage
 initrd http://${mirror}/${dir}/isolinux/initrd.img
-imgargs bzImage load_ramdisk=1 prompt_ramdisk=0 rw printk.time=0 SLACK_KERNEL=huge.s ${params}
+imgargs bzImage load_ramdisk=1 prompt_ramdisk=0 rw printk.time=0 SLACK_KERNEL=huge.s ${params} ${console}
 isset ${debug} && prompt ||
 boot

--- a/src/ubuntu.ipxe
+++ b/src/ubuntu.ipxe
@@ -64,7 +64,7 @@ goto deb_boot
 :deb_boot
 set dir ${dir}${menu}-installer/${arch_a}
 imgfree
-kernel http://${ubuntu_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet ${params}
+kernel http://${ubuntu_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} ${console} -- quiet ${params}
 initrd http://${ubuntu_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:


### PR DESCRIPTION
Adds documents and support for using netboot.xyz with Google
Compute Cloud (GCE).

Console output is redirected to serial when booting the GCE
iPXE disk.