### PR TITLE
Add ALT Linux Rescue

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -69,6 +69,7 @@ You'll need to make sure to have [DOWNLOAD_PROTO_HTTPS](https://github.com/ipxe/
 
 #### Utilities
 
+* [ALT Linux Rescue](https://en.altlinux.org/Rescue)
 * [AVG Rescue CD](http://www.avg.com/us-en/avg-rescue-cd)
 * [Clonezilla](http://www.clonezilla.org/)
 * [DBAN](http://www.dban.org/)

--- a/src/utils.ipxe
+++ b/src/utils.ipxe
@@ -2,6 +2,7 @@
 
 menu Utilities - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Utilities:
+item alt_linux_rescue ${space} ALT Linux Rescue
 item avg ${space} AVG Rescue CD
 item clonezilla ${space} Clonezilla
 item dban ${space} DBAN
@@ -25,6 +26,17 @@ echo ${cls}
 goto ${menu} ||
 chain ${menu}.ipxe || goto utils_exit
 goto utils_exit
+
+:alt_linux_rescue
+iseq ${arch} x86_64 && goto alt_linux_rescue_x64 ||
+set util_path nightly.altlinux.org/sisyphus/tested/regular-rescue-latest-i586.iso
+set util_file regular-rescue-latest-i586.iso
+goto boot_memdisk
+
+:alt_linux_rescue_x64
+set util_path nightly.altlinux.org/sisyphus/tested/regular-rescue-latest-x86_64.iso
+set util_file regular-rescue-latest-x86_64.iso
+goto boot_memdisk
 
 :avg
 set util_path download.avg.com/filedir/inst/avg_arl_cdi_all_120_150814a10442.iso

--- a/src/utils.ipxe
+++ b/src/utils.ipxe
@@ -29,13 +29,13 @@ goto utils_exit
 
 :alt_linux_rescue
 iseq ${arch} x86_64 && goto alt_linux_rescue_x64 ||
-set util_path nightly.altlinux.org/sisyphus/tested/regular-rescue-latest-i586.iso
-set util_file regular-rescue-latest-i586.iso
+set util_path nightly.altlinux.org/p8/release/alt-p8-rescue-20170312-i586.iso
+set util_file alt-p8-rescue-20170312-i586.iso
 goto boot_memdisk
 
 :alt_linux_rescue_x64
-set util_path nightly.altlinux.org/sisyphus/tested/regular-rescue-latest-x86_64.iso
-set util_file regular-rescue-latest-x86_64.iso
+set util_path nightly.altlinux.org/p8/release/alt-p8-rescue-20170312-x86_64.iso
+set util_file alt-p8-rescue-20170312-x86_64.iso
 goto boot_memdisk
 
 :avg


### PR DESCRIPTION
Thanks for making `netboot.xyz`!

This commit adds [ALT Linux Rescue](https://en.altlinux.org/Rescue), a tool which I've used in the past for various maintenance purposes and used again today to get convenient access to `ipmitool` on a series of diskless machines. This image is larger than I'd like -- about 400 MB -- but it works. I put it in the Utilities menu but there's an argument for the Live menu too. 

One snag: I'm unclear on how image signatures are generated. [`prep-release.sh`](https://github.com/antonym/netboot.xyz/blob/master/script/prep-release.sh) signs the scripts, but something else signs the images… right?

I ask because this changeset points to an image which is regularly rebuilt and for which signatures will therefore regularly become invalid. There are [dated builds available](http://nightly.altlinux.org/sisyphus/snapshots/) which could be used to get consistent binaries, but this comes at the cost of periodically updating the date and regenerating the signatures. I would be happy to script that but I don't know where or how best to make that happen.