### PR TITLE
Update UBCD version to 5.3.7

### DIFF
--- a/src/utils.ipxe
+++ b/src/utils.ipxe
@@ -124,8 +124,8 @@ boot
 goto utils_exit
 
 :ubcd
-set util_path mirror.sysadminguide.net/ubcd/ubcd535.iso
-set util_file ubcd535.iso
+set util_path mirror.sysadminguide.net/ubcd/ubcd537.iso
+set util_file ubcd537.iso
 goto boot_memdisk
 
 :boot_memdisk


### PR DESCRIPTION
The 5.3.5 version on the previous mirror is a dead link. This updates the version to the latest (5.3.7).