### PR TITLE
Document floppy image

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ These iPXE disks will automatically load into [boot.netboot.xyz](https://boot.ne
 | Type | Bootloader | Description |
 |------|------------|-------------|
 |ISO| [netboot.xyz.iso](https://boot.netboot.xyz/ipxe/netboot.xyz.iso)| Used for CD/DVD, Virtual CDs like DRAC/iLO, VMware, Virtual Box|
+|Floppy| [netboot.xyz.dsk](https://boot.netboot.xyz/ipxe/netboot.xyz.dsk)| Used for 1.44 MB floppies, Virtual floppies like DRAC/iLO, VMware, Virtual Box|
 |USB| [netboot.xyz.usb](https://boot.netboot.xyz/ipxe/netboot.xyz.usb)| Used for creation of USB Keys|
 |Kernel| [netboot.xyz.lkrn](https://boot.netboot.xyz/ipxe/netboot.xyz.lkrn)| Used for booting from GRUB/EXTLINUX|
 |DHCP| [netboot.xyz.kpxe](https://boot.netboot.xyz/ipxe/netboot.xyz.kpxe)| DHCP boot image file, uses built-in iPXE NIC drivers|

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,6 +10,7 @@ These iPXE disks will automatically load into [boot.netboot.xyz](https://boot.ne
 | Type | Bootloader | Description |
 |------|------------|-------------|
 |ISO| [netboot.xyz.iso](https://boot.netboot.xyz/ipxe/netboot.xyz.iso)| Used for CD/DVD, Virtual CDs like DRAC/iLO, VMware, Virtual Box|
+|Floppy| [netboot.xyz.dsk](https://boot.netboot.xyz/ipxe/netboot.xyz.dsk)| Used for 1.44 MB floppies, Virtual floppies like DRAC/iLO, VMware, Virtual Box|
 |USB| [netboot.xyz.usb](https://boot.netboot.xyz/ipxe/netboot.xyz.usb)| Used for creation of USB Keys|
 |Kernel| [netboot.xyz.lkrn](https://boot.netboot.xyz/ipxe/netboot.xyz.lkrn)| Used for booting from GRUB/EXTLINUX|
 |DHCP| [netboot.xyz.kpxe](https://boot.netboot.xyz/ipxe/netboot.xyz.kpxe)| DHCP boot image file, uses built-in iPXE NIC drivers|


### PR DESCRIPTION
I wanted to use `netboot.xyz` on a Supermicro box that's sitting on a remote network outside my control. The Supermicro IPMI implementation has remote media features, but booting from an ISO (at least on this machine) requires sharing the ISO from a BMC-accessible SMB server, whereas booting from a floppy can be done by uploading the floppy to the BMC straight from the KVM client. I noticed the `netboot.xyz` image would fit on a floppy, so then I set out to make that happen.

After poking around a bit, I noticed that `scripts/prep-release.sh` [already makes a floppy image](https://github.com/antonym/netboot.xyz/blob/master/script/prep-release.sh#L46), and in fact it's [already published](https://boot.netboot.xyz/ipxe/netboot.xyz.dsk). Perfect! This PR adds a link to the website.