### PR TITLE
Punt OpenBSD snapshots to 6.2

### DIFF
--- a/src/openbsd.ipxe
+++ b/src/openbsd.ipxe
@@ -8,13 +8,13 @@ menu OpenBSD
 item 6.1 OpenBSD 6.1
 item 6.0 OpenBSD 6.0
 item 5.9 OpenBSD 5.9
-item snapshots OpenBSD 6.1 Latest Snapshot
+item snapshots OpenBSD 6.2 Latest Snapshot
 choose ver || goto openbsd_exit
 
 iseq ${ver} 6.1 && set image_ver 61 ||
 iseq ${ver} 6.0 && set image_ver 60 ||
 iseq ${ver} 5.9 && set image_ver 59 ||
-iseq ${ver} snapshots && set image_ver 61 ||
+iseq ${ver} snapshots && set image_ver 62 ||
 
 iseq ${arch} x86_64 && goto openbsd_x64 ||
 set openbsd_arch i386


### PR DESCRIPTION
OpenBSD is now at 6.2-current: http://undeadly.org/cgi?action=article&sid=20170821133453