### PR TITLE
update to supported FreeBSD releases

### DIFF
--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -10,10 +10,6 @@ item 11.0 FreeBSD 11.0
 item 10.3 FreeBSD 10.3
 choose ver || goto freebsd_exit
 
-iseq ${ver} 11.1 && set image_ver_major 11 ||
-iseq ${ver} 11.0 && set image_ver_major 11 ||
-iseq ${ver} 10.3 && set image_ver_major 10 ||
-
 iseq ${ver} 11.1 && set image_ver 11.1-RELEASE ||
 iseq ${ver} 11.0 && set image_ver 11.0-RELEASE ||
 iseq ${ver} 10.3 && set image_ver 10.3-RELEASE ||
@@ -27,7 +23,10 @@ set freebsd_arch amd64
 goto boot_freebsd
 
 :boot_freebsd
-set src http://mfsbsd.vx.sk/files/images/${image_ver_major}/mfsbsd-${image_ver}-${freebsd_arch}.img
+iseq ${ver} 11.1 && set image_subdir 11 ||
+iseq ${ver} 11.0 && set image_subdir 11 ||
+iseq ${ver} 10.3 && set image_subdir 10/${freebsd_arch} ||
+set src http://mfsbsd.vx.sk/files/images/${image_subdir}/mfsbsd-${image_ver}-${freebsd_arch}.img
 imgfree
 echo This loads an mfsbsd installer (http://mfsbsd.vx.sk/).  
 echo Root password for all images: mfsroot

--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -23,10 +23,10 @@ set freebsd_arch amd64
 goto boot_freebsd
 
 :boot_freebsd
-set src https://download.freebsd.org/ftp/releases/ISO-IMAGES/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-bootonly.iso
+set src https://download.freebsd.org/ftp/releases/ISO-IMAGES/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-mini-memstick.img
 imgfree
 initrd ${src}
-chain ${memdisk} iso raw
+chain ${memdisk} harddisk raw
 exit
 
 :freebsd_exit

--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -6,17 +6,17 @@
 :freebsd_menu
 menu Please pick a FreeBSD version
 item 11.1 FreeBSD 11.1
-item 10.2 FreeBSD 10.2
-item 10.1 FreeBSD 10.1
-item 10.0 FreeBSD 10.0
+item 11.0 FreeBSD 11.0
+item 10.3 FreeBSD 10.3
 choose ver || goto freebsd_exit
 
 iseq ${ver} 11.1 && set image_ver_major 11 ||
+iseq ${ver} 11.0 && set image_ver_major 11 ||
+iseq ${ver} 10.3 && set image_ver_major 10 ||
 
 iseq ${ver} 11.1 && set image_ver 11.1-RELEASE ||
-iseq ${ver} 10.2 && set image_ver 10.2-RELEASE ||
-iseq ${ver} 10.1 && set image_ver 10.1-RELEASE ||
-iseq ${ver} 10.0 && set image_ver 10.0-RELEASE ||
+iseq ${ver} 11.0 && set image_ver 11.0-RELEASE ||
+iseq ${ver} 10.3 && set image_ver 10.3-RELEASE ||
 
 iseq ${arch} x86_64 && goto freebsd_x64 ||
 set freebsd_arch i386
@@ -27,7 +27,6 @@ set freebsd_arch amd64
 goto boot_freebsd
 
 :boot_freebsd
-# set src http://boot.rackspace.com/distros/freebsd/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-bootonly-mfsbsd.hd
 set src http://mfsbsd.vx.sk/files/images/${image_ver_major}/mfsbsd-${image_ver}-${freebsd_arch}.img
 imgfree
 echo This loads an mfsbsd installer (http://mfsbsd.vx.sk/).  

--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -23,8 +23,20 @@ set freebsd_arch amd64
 goto boot_freebsd
 
 :boot_freebsd
-set src https://download.freebsd.org/ftp/releases/ISO-IMAGES/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-mini-memstick.img
+iseq ${ver} 11.1 && set image_subdir 11 ||
+iseq ${ver} 11.0 && set image_subdir 11 ||
+iseq ${ver} 10.3 && set image_subdir 10/${freebsd_arch} ||
+set src http://mfsbsd.vx.sk/files/images/${image_subdir}/mfsbsd-${image_ver}-${freebsd_arch}.img
 imgfree
+echo This loads an mfsbsd installer (http://mfsbsd.vx.sk/).  
+echo Root password for all images: mfsroot
+echo You'll need to configure networking manually for the installer disk as 
+echo it uses dhcp by default:
+echo ifconfig xn0 inet <public ip> netmask 255.255.255.0
+echo route delete default; route add default <public ip x.x.x.1>
+echo echo "nameserver x.x.x.x" > /etc/resolv.conf
+echo Once network is configured, you can launch the usual installer:
+echo bsdinstall
 initrd ${src}
 chain ${memdisk} harddisk raw
 exit

--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -23,10 +23,10 @@ set freebsd_arch amd64
 goto boot_freebsd
 
 :boot_freebsd
-set src https://download.freebsd.org/ftp/releases/ISO-IMAGES/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-mini-memstick.img
+set src https://download.freebsd.org/ftp/releases/ISO-IMAGES/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-bootonly.iso
 imgfree
 initrd ${src}
-chain ${memdisk} harddisk raw
+chain ${memdisk} iso raw
 exit
 
 :freebsd_exit

--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -5,11 +5,15 @@
 
 :freebsd_menu
 menu Please pick a FreeBSD version
+item 11.1 FreeBSD 11.1
 item 10.2 FreeBSD 10.2
 item 10.1 FreeBSD 10.1
 item 10.0 FreeBSD 10.0
 choose ver || goto freebsd_exit
 
+iseq ${ver} 11.1 && set image_ver_major 11 ||
+
+iseq ${ver} 11.1 && set image_ver 11.1-RELEASE ||
 iseq ${ver} 10.2 && set image_ver 10.2-RELEASE ||
 iseq ${ver} 10.1 && set image_ver 10.1-RELEASE ||
 iseq ${ver} 10.0 && set image_ver 10.0-RELEASE ||
@@ -23,7 +27,8 @@ set freebsd_arch amd64
 goto boot_freebsd
 
 :boot_freebsd
-set src http://boot.rackspace.com/distros/freebsd/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-bootonly-mfsbsd.hd
+# set src http://boot.rackspace.com/distros/freebsd/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-bootonly-mfsbsd.hd
+set src http://mfsbsd.vx.sk/files/images/${image_ver_major}/mfsbsd-${image_ver}-${freebsd_arch}.img
 imgfree
 echo This loads an mfsbsd installer (http://mfsbsd.vx.sk/).  
 echo Root password for all images: mfsroot

--- a/src/freebsd.ipxe
+++ b/src/freebsd.ipxe
@@ -23,20 +23,8 @@ set freebsd_arch amd64
 goto boot_freebsd
 
 :boot_freebsd
-iseq ${ver} 11.1 && set image_subdir 11 ||
-iseq ${ver} 11.0 && set image_subdir 11 ||
-iseq ${ver} 10.3 && set image_subdir 10/${freebsd_arch} ||
-set src http://mfsbsd.vx.sk/files/images/${image_subdir}/mfsbsd-${image_ver}-${freebsd_arch}.img
+set src https://download.freebsd.org/ftp/releases/ISO-IMAGES/${ver}/FreeBSD-${image_ver}-${freebsd_arch}-mini-memstick.img
 imgfree
-echo This loads an mfsbsd installer (http://mfsbsd.vx.sk/).  
-echo Root password for all images: mfsroot
-echo You'll need to configure networking manually for the installer disk as 
-echo it uses dhcp by default:
-echo ifconfig xn0 inet <public ip> netmask 255.255.255.0
-echo route delete default; route add default <public ip x.x.x.1>
-echo echo "nameserver x.x.x.x" > /etc/resolv.conf
-echo Once network is configured, you can launch the usual installer:
-echo bsdinstall
 initrd ${src}
 chain ${memdisk} harddisk raw
 exit


### PR DESCRIPTION
This updates FreeBSD installers to 11.1, 11.0, and 10.3, which are versions currently supported upstream. This also changes upstream site to mfsbsd. I tested this with all three installers with x86_64, but unfortunately 10.0-RELEASE was the last release available from mfsbsd with i386 image for it.