### PR TITLE
coreos: add missing initrd= parameter

### DIFF
--- a/src/coreos.ipxe
+++ b/src/coreos.ipxe
@@ -27,7 +27,7 @@ goto coreos_exit
 :alpha
 set release ${menu}
 set base-url http://${release}.release.core-os.net/amd64-usr/current
-kernel ${base-url}/coreos_production_pxe.vmlinuz ${coreos_params} ${console} coreos.autologin=tty1 coreos.autologin=ttyS0
+kernel ${base-url}/coreos_production_pxe.vmlinuz ${coreos_params} ${console} coreos.autologin=tty1 coreos.autologin=ttyS0 initrd=coreos_production_pxe_image.cpio.gz
 initrd ${base-url}/coreos_production_pxe_image.cpio.gz
 boot
 goto coreos_exit


### PR DESCRIPTION
Without this parameter, boot fails with
“Failed to open 'baselayout.conf' : No such file of directory”

See https://coreos.com/os/docs/latest/booting-with-ipxe.html for more details.