### PR TITLE
Fedora 25 is eol

### DIFF
--- a/src/fedora.ipxe
+++ b/src/fedora.ipxe
@@ -14,8 +14,6 @@ menu Fedora - ${arch} - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Latest Releases
 item 27 ${space} ${os} 27
 item 26 ${space} ${os} 26
-item 25 ${space} ${os} 25
-item 24 ${space} ${os} 24
 isset ${osversion} || choose osversion || goto linux_menu
 set ova ${os} ${osversion}
 goto product_sku


### PR DESCRIPTION
Fedora 25 is now End-of-life. Thus Fedora 24 is already (August 2017).

As a reference: https://fedoramagazine.org/fedora-25-end-life/