### PR TITLE
add Alpine Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Full documentation is at ReadTheDocs:
 
 ### What Operating Systems are available?
 
+* [Alpine Linux](https://alpinelinux.org)
 * [Antergos](https://antergos.com)
 * [Arch Linux](https://www.archlinux.org)
 * [CentOS](https://centos.org)

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ You'll need to make sure to have [DOWNLOAD_PROTO_HTTPS](https://github.com/ipxe/
 
 #### What Operating Systems are currently available on netboot.xyz?
 
+* [Alpine Linux](https://alpinelinux.org)
 * [Antergos](https://antergos.com)
 * [Arch Linux](https://www.archlinux.org)
 * [CentOS](https://centos.org)

--- a/src/alpinelinux.ipxe
+++ b/src/alpinelinux.ipxe
@@ -1,0 +1,29 @@
+#!ipxe
+
+# Alpine Linux
+# https://alpinelinux.org
+
+goto ${menu}
+
+:alpinelinux
+set os Alpine Linux
+iseq ${arch} x86_64 && set bootarch x86_64 || set bootarch x86
+
+menu ${os} [${bootarch}]
+item latest-stable Latest stable
+item edge Edge (development)
+choose version || goto alpine_exit
+goto boot
+
+:boot
+set base-url http://dev.alpinelinux.org/~clandmeter/netboot/${version}/${bootarch}
+set repo-url http://${alpinelinux_mirror}/${alpinelinux_base_dir}/${version}/main
+imgfree
+kernel ${base-url}/vmlinuz-vanilla alpine_repo=${repo-url} modules=loop,squashfs modloop=${base-url}/modloop-vanilla quiet nomodeset
+initrd ${base-url}/initramfs-vanilla
+boot
+goto alpine_exit
+
+:alpine_exit
+clear menu
+exit 0

--- a/src/boot.cfg
+++ b/src/boot.cfg
@@ -26,6 +26,10 @@ set ipxe_disk netboot.xyz-undionly.kpxe
 # official mirrors
 ##################
 :mirrors
+### Alpine Linux
+set alpinelinux_mirror dl-cdn.alpinelinux.org
+set alpinelinux_base_dir alpine
+
 ### ArchLinux
 set archlinux_mirror mirror.rackspace.com
 set archlinux_base_dir archlinux

--- a/src/linux.ipxe
+++ b/src/linux.ipxe
@@ -15,6 +15,7 @@ item manjaro ${space} Manjaro Linux
 item opensuse ${space} openSUSE
 item ubuntu ${space} Ubuntu
 item --gap All Others:
+item alpinelinux ${space} Alpine Linux (Experimental)
 item antergos ${space} Antergos
 item coreos ${space} CoreOS
 item devuan ${space} Devuan


### PR DESCRIPTION
This is a first attempt of adding Alpine Linux to netboot.xyz.

We currently do not "officially" ship netboot images but this is high on my prio list. Instead I've added images for both x86 and x86_64 from both stable and edge releases to our dev server. I also have a few small patches ready to go into Alpine Linux to fix some corner cases which will be applied asap.

This has been tested with my custom [ipxe script ](https://github.com/clandmeter/netboot.xyz-custom/blob/master/custom.ipxe). Please check if i missed anything.

ref: #30

