### PR TITLE
Update utils.ipxe - Breakin

### DIFF
--- a/src/utils.ipxe
+++ b/src/utils.ipxe
@@ -4,7 +4,7 @@ menu Utilities - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Utilities:
 item alt_linux_rescue ${space} ALT Linux Rescue
 item avg ${space} AVG Rescue CD
-item breakin ${space} Breakin
+item breakin ${space} Breakin v4.26.1-53 (2015-10-22) - Hardware stress-test (x64 only)
 item clonezilla ${space} Clonezilla
 item dban ${space} DBAN
 item gparted ${space} GParted
@@ -42,6 +42,8 @@ set util_file avg_arl_cdi_all_120_${avg_version}.iso
 goto boot_memdisk
 
 :breakin
+# Website : http://www.advancedclustering.com/products/software/breakin
+# Download: http://www.advancedclustering.com/act_downloads/breakin
 set breakin_version 4.26.1-53
 set util_path www.advancedclustering.com/wp-content/uploads/2017/02/bootimage-${breakin_version}.iso
 set util_file bootimage-${breakin_version}.iso


### PR DESCRIPTION
* Added note that it supports only amd64/x64. Booting on a i686 machine will fail as this tool was build for servers and clusters in mind, not for old desktops/laptops.
* Added version and description: v4.26.1-53 (2015-10-22) - Hardware stress-test 
* Added comments for website and download link.
They have a PXE image as well. Can iPXE download http://www.advancedclustering.com/wp-content/uploads/2017/02/bootimage-4.26.1-53.tbz2 and untar on the fly and then load kernel and initrd?