### PR TITLE
Update Centos 6.9 -> 6.10

### DIFF
--- a/src/centos.ipxe
+++ b/src/centos.ipxe
@@ -10,10 +10,10 @@ clear osversion
 set os CentOS
 menu ${os} - ${arch} - Image Sig Checks: [${img_sigs_enabled}]
 item 7.5.1804 ${os} 7.5
-item 6.9 ${os} 6.9
+item 6.10 ${os} 6.10
 isset ${osversion} || choose osversion || goto linux_menu
 echo ${cls}
-iseq ${osversion} 6.9 && set dir ${menu}/${osversion}/os/${arch} ||
+iseq ${osversion} 6.10 && set dir ${menu}/${osversion}/os/${arch} ||
 set dir ${centos_base_dir}/${osversion}/os/x86_64
 set repo http://${centos_mirror}/${dir}
 goto boottype


### PR DESCRIPTION
This updates the minor version of Centos 6.9 to 6.10. I'm not sure if anyone is still installing Centos 6 for new servers, but it wont be EOL until [November 30, 2020](https://wiki.centos.org/FAQ/General#head-fe8a0be91ee3e7dea812e8694491e1dde5b75e6d), so we might as well keep a boot option for it.

Tested on my T61 Thinkpad.