### PR TITLE
Bump Arch and Antergos versions

### DIFF
--- a/src/antergos.ipxe
+++ b/src/antergos.ipxe
@@ -7,7 +7,7 @@ goto ${menu}
 
 :antergos
 set os Antergos
-set antergos_version 18.10
+set antergos_version 18.11
 menu ${os} Installers
 item x86_64 ${space} ${os} ${antergos_version} Minimal 64bit [ISO]
 choose antergos_arch || goto antergos_exit

--- a/src/archlinux.ipxe
+++ b/src/archlinux.ipxe
@@ -11,7 +11,7 @@ clear arch_version
 menu ${os} - ${arch} - Image Sig Checks: [${img_sigs_enabled}]
 menu Arch Linux
 item --gap Latest Releases
-item 2018.10.01 2018.10.01
+item 2018.11.01 2018.11.01
 choose arch_version || goto archlinux_exit
 goto boot
 


### PR DESCRIPTION
Arch: 2018.10.01 -> 2018.11.01
Antergos: 18.10 -> 18.11