### PR TITLE
Update archlinux to 2019.02.01

### DIFF
--- a/src/archlinux.ipxe
+++ b/src/archlinux.ipxe
@@ -11,7 +11,7 @@ clear arch_version
 menu ${os} - ${arch} - Image Sig Checks: [${img_sigs_enabled}]
 menu Arch Linux
 item --gap Latest Releases
-item 2019.01.01 2019.01.01
+item 2019.02.01 2019.02.01
 choose arch_version || goto archlinux_exit
 goto boot
 


### PR DESCRIPTION
There's a new image for Archlinux, which this PR updates

I've tested this on my laptop and it boots fine