### PR TITLE
Update ubuntu.ipxe

### DIFF
--- a/src/ubuntu.ipxe
+++ b/src/ubuntu.ipxe
@@ -10,10 +10,10 @@ set os Ubuntu
 clear ubuntu_version
 menu ${os} - ${arch_a} - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Latest Releases
+item disco ${space} ${os} 19.04 Disco Dingo
 item cosmic ${space} ${os} 18.10 Cosmic Cuttlefish
 item bionic ${space} ${os} 18.04 LTS Bionic Beaver
 item xenial ${space} ${os} 16.04 LTS Xenial Xerus
-item trusty ${space} ${os} 14.04 LTS Trusty Tahr
 item --gap Older Releases
 item older_release ${space} Set release codename...
 choose ubuntu_version || goto ubuntu_exit


### PR DESCRIPTION
removes 14.04 & adds 19.04

Merge after 2019-04-18 as per https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions when disco is released