### PR TITLE
Add Flatcar Linux as a boot option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Full documentation is at netboot.xyz:
 * [Debian](https://debian.org)
 * [Devuan](https://devuan.org)
 * [Fedora](https://fedoraproject.org)
+* [Flatcar Linux](https://www.flatcar-linux.org)
 * [FreeBSD](https://freebsd.org)
 * [FreeDOS](http://www.freedos.org)
 * [Gentoo](https://gentoo.org)
@@ -87,4 +88,3 @@ Under the **Utilities** menu on netboot.xyz, there's an option for ["Test netboo
 #### Feedback
 
 Feel free to open up an [issue](https://github.com/antonym/netboot.xyz/issues) on Github, swing by [Freenode IRC](http://freenode.net/) in the [#netbootxyz](http://webchat.freenode.net/?channels=#netbootxyz) channel, or ping us on [Gitter](https://gitter.im/antonym/netboot.xyz?utm_source=share-link&utm_medium=link&utm_campaign=share-link).  Follow us on [Twitter](https://twitter.com/netbootxyz) or like us on [Facebook](https://www.facebook.com/netboot.xyz)!
-

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -34,7 +34,7 @@ initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot
 goto flatcar_exit
 
-:cloud_config
+:ignition_config
 echo -n Please set Ignition URL: && read ignition-config-url
 set flatcar_params flatcar.config.url=${ignition-config-url}
 clear menu

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -1,0 +1,45 @@
+#!ipxe
+
+# Container Linux by flatcar
+# https://www.flatcar.com
+# For further info on:
+# iPXE and flatcar Container Linux: https://flatcar.com/os/docs/latest/booting-with-ipxe.html
+# Setting up Cloud Config: https://github.com/flatcar/flatcar-cloudinit
+# 64-bit only
+
+goto ${menu}
+
+:flatcar
+set os Flatcar Linux
+menu ${os}
+item --gap ${os}:
+item stable ${space} ${os} Stable Channel
+item beta ${space} ${os} Beta Channel
+item alpha ${space} ${os} Alpha Channel
+item edge ${space} ${os} Edge Channel
+item cloud_config ${space} Set cloud-config-url: ${cloud-config-url}
+choose --default ${menu} menu || goto flatcar_exit
+echo ${cls}
+goto ${menu} ||
+goto flatcar_exit
+
+:stable
+:beta
+:alpha
+:edge
+set release ${menu}
+set base-url http://${release}.release.core-os.net/amd64-usr/current
+kernel ${base-url}/flatcar_production_pxe.vmlinuz ${flatcar_params} ${console} flatcar.autologin=tty1 flatcar.autologin=ttyS0 initrd=flatcar_production_pxe_image.cpio.gz
+initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
+boot
+goto flatcar_exit
+
+:cloud_config
+echo -n Please set Cloud Config URL: && read cloud-config-url
+set flatcar_params cloud-config-url=${cloud-config-url}
+clear menu
+goto flatcar
+
+:flatcar_exit
+clear menu
+exit 0

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -35,8 +35,8 @@ boot
 goto flatcar_exit
 
 :cloud_config
-echo -n Please set Cloud Config URL: && read cloud-config-url
-set flatcar_params "flatcar.first_boot=1 flatcar.config.url=${cloud-config-url}"
+echo -n Please set Ignition URL: && read ignition-config-url
+set flatcar_params flatcar.config.url=${ignition-config-url}
 clear menu
 goto flatcar
 

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -29,7 +29,7 @@ goto flatcar_exit
 :edge
 set release ${menu}
 set base-url http://${release}.release.flatcar-linux.net/amd64-usr/current
-kernel ${base-url}/flatcar_production_pxe.vmlinuz ${flatcar_params} ${console} flatcar.autologin=tty1 flatcar.autologin=ttyS0 initrd=flatcar_production_pxe_image.cpio.gz
+kernel ${base-url}/flatcar_production_pxe.vmlinuz ${flatcar_firstboot} ${flatcar_params} ${console} flatcar.autologin=tty1 flatcar.autologin=ttyS0 initrd=flatcar_production_pxe_image.cpio.gz
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot
 goto flatcar_exit
@@ -37,6 +37,7 @@ goto flatcar_exit
 :ignition_config
 echo -n Please set Ignition URL: && read flatcar.config.url
 set flatcar_params flatcar.config.url=${flatcar.config.url}
+set flatcar_firstboot flatcar.first_boot=1
 clear menu
 goto flatcar
 

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -4,7 +4,7 @@
 # https://www.flatcar.com
 # For further info on:
 # iPXE and flatcar Container Linux: https://docs.flatcar-linux.org/os/booting-with-ipxe/
-# Setting up Cloud Config: https://github.com/flatcar-linux/coreos-cloudinit
+# Setting up Ignition: https://docs.flatcar-linux.org/os/provisioning/
 # 64-bit only
 
 goto ${menu}
@@ -17,7 +17,7 @@ item stable ${space} ${os} Stable Channel
 item beta ${space} ${os} Beta Channel
 item alpha ${space} ${os} Alpha Channel
 item edge ${space} ${os} Edge Channel
-item cloud_config ${space} Set cloud-config-url: ${cloud-config-url}
+item ignition_config ${space} Set flatcar.config.url: ${flatcar.config.url}
 choose --default ${menu} menu || goto flatcar_exit
 echo ${cls}
 goto ${menu} ||
@@ -36,7 +36,7 @@ goto flatcar_exit
 
 :cloud_config
 echo -n Please set Cloud Config URL: && read cloud-config-url
-set flatcar_params cloud-config-url=${cloud-config-url}
+set flatcar_params flatcar.first_boot=1 flatcar.config.url=${cloud-config-url}
 clear menu
 goto flatcar
 

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -3,8 +3,8 @@
 # Container Linux by flatcar
 # https://www.flatcar.com
 # For further info on:
-# iPXE and flatcar Container Linux: https://flatcar.com/os/docs/latest/booting-with-ipxe.html
-# Setting up Cloud Config: https://github.com/flatcar/flatcar-cloudinit
+# iPXE and flatcar Container Linux: https://docs.flatcar-linux.org/os/booting-with-ipxe/
+# Setting up Cloud Config: https://github.com/flatcar-linux/coreos-cloudinit
 # 64-bit only
 
 goto ${menu}
@@ -28,7 +28,7 @@ goto flatcar_exit
 :alpha
 :edge
 set release ${menu}
-set base-url http://${release}.release.core-os.net/amd64-usr/current
+set base-url http://${release}.release.flatcar-linux.net/amd64-usr/current
 kernel ${base-url}/flatcar_production_pxe.vmlinuz ${flatcar_params} ${console} flatcar.autologin=tty1 flatcar.autologin=ttyS0 initrd=flatcar_production_pxe_image.cpio.gz
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -35,8 +35,8 @@ boot
 goto flatcar_exit
 
 :ignition_config
-echo -n Please set Ignition URL: && read ignition-config-url
-set flatcar_params flatcar.config.url=${ignition-config-url}
+echo -n Please set Ignition URL: && read flatcar.config.url
+set flatcar_params flatcar.config.url=${flatcar.config.url}
 clear menu
 goto flatcar
 

--- a/src/flatcar.ipxe
+++ b/src/flatcar.ipxe
@@ -36,7 +36,7 @@ goto flatcar_exit
 
 :cloud_config
 echo -n Please set Cloud Config URL: && read cloud-config-url
-set flatcar_params flatcar.first_boot=1 flatcar.config.url=${cloud-config-url}
+set flatcar_params "flatcar.first_boot=1 flatcar.config.url=${cloud-config-url}"
 clear menu
 goto flatcar
 

--- a/src/linux.ipxe
+++ b/src/linux.ipxe
@@ -7,7 +7,7 @@ menu Linux Installers - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 item --gap Popular Linux Operating Systems:
 item archlinux ${space} Arch Linux
-item centos ${space} CentOS 
+item centos ${space} CentOS
 item debian ${space} Debian
 item fedora ${space} Fedora
 item mageia ${space} Mageia
@@ -18,6 +18,7 @@ item --gap All Others:
 item alpinelinux ${space} Alpine Linux
 item coreos ${space} CoreOS
 item devuan ${space} Devuan
+item flatcar ${space} Flatcar
 item gentoo ${space} Gentoo Linux
 item ipfire ${space} IPFire
 item nixos ${space} NixOS


### PR DESCRIPTION
Adds the fork of CoreOS called [Flatcar Linux](https://www.flatcar-linux.org/) as a boot option. It also adds a release target that is unique to flatcar called "Edge" as a deploy target. 

I debated adding this into the Menu as a set of sub options for CoreOS since they are so closely related, but ultimately decided that this made more sense to split it out, particularly in light of the uncertain future of CoreOS as it transition to Fedora CoreOS, and what is a completely different OS. 

