### PR TITLE
Bump Alpine to v3.10

### DIFF
--- a/src/alpinelinux.ipxe
+++ b/src/alpinelinux.ipxe
@@ -11,7 +11,7 @@ set os Alpine Linux
 iseq ${arch} x86_64 && set bootarch x86_64 || set bootarch x86
 menu ${os} [${bootarch}] - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Latest Releases
-item v3.9 ${space} ${os} 3.9
+item v3.10 ${space} ${os} 3.10
 item --gap Development Releases
 item edge ${space} ${os} Edge (development)
 choose alpine_version || goto alpine_exit


### PR DESCRIPTION
Alpine Linux's latest version is 3.10. netboot.xyz currently has options for 3.9 (the second-latest version) and edge.

This updates the options to 3.10 and edge.
