### PR TITLE
Static IP support

### DIFF
--- a/src/alpinelinux.ipxe
+++ b/src/alpinelinux.ipxe
@@ -3,6 +3,8 @@
 # Alpine Linux
 # https://alpinelinux.org
 
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}::eth0:none:${dns}
+
 goto ${menu}
 
 :alpinelinux
@@ -22,7 +24,7 @@ set base-url http://${alpinelinux_mirror}
 set dir ${alpinelinux_base_dir}/${alpine_version}/releases/${bootarch}/netboot
 set repo-url ${base-url}/${alpinelinux_base_dir}/${alpine_version}/main
 imgfree
-kernel ${base-url}/${dir}/vmlinuz-vanilla alpine_repo=${repo-url} modules=loop,squashfs modloop=${base-url}/${dir}/modloop-vanilla quiet nomodeset
+kernel ${base-url}/${dir}/vmlinuz-vanilla ${ipparam} alpine_repo=${repo-url} modules=loop,squashfs modloop=${base-url}/${dir}/modloop-vanilla quiet nomodeset
 initrd ${base-url}/${dir}/initramfs-vanilla
 echo
 echo MD5sums:

--- a/src/archlinux.ipxe
+++ b/src/archlinux.ipxe
@@ -3,6 +3,19 @@
 # Arch Linux Operating System
 # http://www.archlinux.org
 
+isset ${dhcp-server} || goto static_ip
+set ipparam BOOTIF=${netX/mac} ip=dhcp
+set real_archlinux_mirror ${archlinux_mirror}
+goto goto_menu
+
+:static_ip
+# Arch Linux cannot use DNS if booted with a static IP
+# See https://bugs.archlinux.org/task/63174
+# Remove this hack when the above bug is properly resolved
+nslookup real_archlinux_mirror ${archlinux_mirror}
+set ipparam BOOTIF=${netX/mac} ip=${ip}::${gateway}:${netmask}
+
+:goto_menu
 goto ${menu} ||
 
 :archlinux
@@ -18,7 +31,7 @@ goto boot
 :boot
 imgfree
 set dir ${archlinux_base_dir}/iso/${arch_version}/arch/boot
-set params initrd=archiso.img archiso_http_srv=http://${archlinux_mirror}/${archlinux_base_dir}/iso/${arch_version}/ archisobasedir=arch verify=y ip=dhcp net.ifnames=0 ${console}
+set params initrd=archiso.img archiso_http_srv=http://${real_archlinux_mirror}/${archlinux_base_dir}/iso/${arch_version}/ archisobasedir=arch verify=y ${ipparam} net.ifnames=0 ${console}
 kernel http://${archlinux_mirror}/${dir}/x86_64/vmlinuz ${params} initrd=archiso.img
 initrd http://${archlinux_mirror}/${dir}/x86_64/archiso.img
 echo

--- a/src/centos.ipxe
+++ b/src/centos.ipxe
@@ -3,6 +3,9 @@
 # CentOS Operating System
 # http://www.centos.org
 
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+set ipparam BOOTIF=${netX/mac} ${ipparam}
+
 goto ${menu} ||
 
 :centos
@@ -56,7 +59,7 @@ goto boottype
 
 :bootos_images
 imgfree
-kernel http://${centos_mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${console} BOOTIF=${netX/mac} ip=dhcp initrd=initrd.img
+kernel http://${centos_mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${console} ${ipparam} initrd=initrd.img
 initrd http://${centos_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/src/fedora.ipxe
+++ b/src/fedora.ipxe
@@ -3,6 +3,9 @@
 # Fedora Operating System
 # https://getfedora.org/
 
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+set ipparam BOOTIF=${netX/mac} ${ipparam}
+
 goto ${menu} ||
 
 :fedora
@@ -54,7 +57,7 @@ goto boot
 
 :boot
 imgfree
-kernel http://${fedora_mirror}/${dir}/images/pxeboot/vmlinuz repo=http://${fedora_mirror}/${dir} ${params} ${console} BOOTIF=${netX/mac} ip=dhcp initrd=initrd.img
+kernel http://${fedora_mirror}/${dir}/images/pxeboot/vmlinuz repo=http://${fedora_mirror}/${dir} ${params} ${console} ${ipparam} initrd=initrd.img
 initrd http://${fedora_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/src/mageia.ipxe
+++ b/src/mageia.ipxe
@@ -3,6 +3,9 @@
 # Mageia Operating System
 # http://www.mageia.org/
 
+# No way to set the network interface by MAC address, let the installer ask the question
+isset ${dhcp-server} && set network dhcp || set network static,ip:${ip},netmask:${netmask},gateway:${gateway},dns:${dns}
+
 goto ${menu} ||
 
 :mageia
@@ -18,7 +21,7 @@ goto mageia_boot
 :mageia_boot
 set dir ${mageia_base_dir}/distrib/${version}/x86_64 && set dir2 isolinux/x86_64 ||
 iseq ${arch} i386 && set dir ${mageia_base_dir}/distrib/${version}/i586 && set dir2 isolinux/i386 ||
-set automatic method:http,network:dhcp,server:${mageia_mirror},directory:/${dir}
+set automatic method:http,network:${network},server:${mageia_mirror},directory:/${dir}
 imgfree
 kernel http://${mageia_mirror}/${dir}/${dir2}/vmlinuz
 initrd http://${mageia_mirror}/${dir}/${dir2}/all.rdz

--- a/src/opensuse.ipxe
+++ b/src/opensuse.ipxe
@@ -2,6 +2,60 @@
 
 # OpenSUSE Operating System
 # http://opensuse.org
+
+isset ${dhcp-server} || goto static_ip
+set netsetup netsetup=dhcp
+goto goto_menu
+
+:static_ip
+# Need to convert netmask into prefix, because otherwise the installer
+# accepts it but configures the network with /32 prefix, which installs
+# fine but breaks connectivity to devices in the same network.
+set prefix 32
+
+iseq ${netmask} 0.0.0.0 && set prefix 0 ||
+
+iseq ${netmask} 128.0.0.0 && set prefix 1 ||
+iseq ${netmask} 192.0.0.0 && set prefix 2 ||
+iseq ${netmask} 224.0.0.0 && set prefix 3 ||
+iseq ${netmask} 240.0.0.0 && set prefix 4 ||
+iseq ${netmask} 248.0.0.0 && set prefix 5 ||
+iseq ${netmask} 252.0.0.0 && set prefix 6 ||
+iseq ${netmask} 254.0.0.0 && set prefix 7 ||
+iseq ${netmask} 255.0.0.0 && set prefix 8 ||
+
+iseq ${netmask} 255.128.0.0 && set prefix 9 ||
+iseq ${netmask} 255.192.0.0 && set prefix 10 ||
+iseq ${netmask} 255.224.0.0 && set prefix 11 ||
+iseq ${netmask} 255.240.0.0 && set prefix 12 ||
+iseq ${netmask} 255.248.0.0 && set prefix 13 ||
+iseq ${netmask} 255.252.0.0 && set prefix 14 ||
+iseq ${netmask} 255.254.0.0 && set prefix 15 ||
+iseq ${netmask} 255.255.0.0 && set prefix 16 ||
+
+iseq ${netmask} 255.255.128.0 && set prefix 17 ||
+iseq ${netmask} 255.255.192.0 && set prefix 18 ||
+iseq ${netmask} 255.255.224.0 && set prefix 19 ||
+iseq ${netmask} 255.255.240.0 && set prefix 20 ||
+iseq ${netmask} 255.255.248.0 && set prefix 21 ||
+iseq ${netmask} 255.255.252.0 && set prefix 22 ||
+iseq ${netmask} 255.255.254.0 && set prefix 23 ||
+iseq ${netmask} 255.255.255.0 && set prefix 24 ||
+
+iseq ${netmask} 255.255.255.128 && set prefix 25 ||
+iseq ${netmask} 255.255.255.192 && set prefix 26 ||
+iseq ${netmask} 255.255.255.224 && set prefix 27 ||
+iseq ${netmask} 255.255.255.240 && set prefix 28 ||
+iseq ${netmask} 255.255.255.248 && set prefix 29 ||
+iseq ${netmask} 255.255.255.252 && set prefix 30 ||
+iseq ${netmask} 255.255.255.254 && set prefix 31 ||
+iseq ${netmask} 255.255.255.255 && set prefix 32 ||
+
+set netsetup netsetup=hostip,gateway,nameserver hostip=${ip}/${prefix} gateway=${gateway} nameserver=${dns}
+
+:goto_menu
+set netsetup ${netsetup} BOOTIF=${netX/mac}
+
 set distro opensuse
 menu openSUSE - ${arch} - Image Sig Checks: [${img_sigs_enabled}]
 item 15.1 openSUSE Leap 15.1
@@ -15,7 +69,7 @@ iseq ${version} tumbleweed && set dir ${version}/repo/oss ||
 imgfree
 kernel http://${opensuse_mirror}/${dir}/boot/x86_64/loader/linux
 initrd http://${opensuse_mirror}/${dir}/boot/x86_64/loader/initrd
-imgargs linux netsetup=dhcp install=http://${opensuse_mirror}/${dir} ${params} ${netcfg} ${console} initrd=initrd
+imgargs linux ${netsetup} install=http://${opensuse_mirror}/${dir} ${params} ${netcfg} ${console} initrd=initrd
 echo
 echo MD5sums:
 md5sum linux initrd

--- a/src/rhel.ipxe
+++ b/src/rhel.ipxe
@@ -3,6 +3,9 @@
 # Redhat Enterprise Linux (RHEL)
 # https://www.redhat.com
 
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+set ipparam BOOTIF=${netX/mac} ${ipparam}
+
 set rhel_arch x86_64
 goto ${menu} ||
 
@@ -40,7 +43,7 @@ isset ${rhel_base_url} && goto boot || echo URL not set... && goto url_set
 
 :boot
 imgfree
-kernel ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz repo=${rhel_base_url}/os/${rhel_arch} ${console} BOOTIF=${netX/mac} ip=dhcp initrd=initrd.img
+kernel ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz repo=${rhel_base_url}/os/${rhel_arch} ${console} ${ipparam} initrd=initrd.img
 initrd ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/initrd.img
 md5sum vmlinuz initrd.img
 boot

--- a/src/scientific.ipxe
+++ b/src/scientific.ipxe
@@ -3,6 +3,9 @@
 # Scientific Linux Operating System
 # https://www.scientificlinux.org/
 
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+set ipparam BOOTIF=${netX/mac} ${ipparam}
+
 goto ${menu} ||
 
 :scientific
@@ -47,7 +50,7 @@ goto bootos_images
 
 :bootos_images
 imgfree
-kernel http://ftp1.scientificlinux.org/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${netcfg} ${console}
+kernel http://ftp1.scientificlinux.org/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${netcfg} ${console} ${ipparam}
 initrd http://ftp1.scientificlinux.org/${dir}/images/pxeboot/initrd.img
 boot
 goto linux_menu


### PR DESCRIPTION
See #342 but this pull request is not limited to CentOS.

I have verified that all Linux distributions offered by linux.ipxe. Status with the static IP configured via the failsafe menu:
 - Alpine boots correctly only if the first network card is used
 - Arch relies on http://ip.address.of.mirror/ to work (bug reported upstream)
 - Gentoo and IPFire do not boot at all, also before my patches
 - RHEL not tested
 - Everything else in the menu works

Regarding Gentoo, the snapshot offered is very old, and it is possible to [use third-party live/rescue Linux systems to install Gentoo](https://wiki.gentoo.org/wiki/Installation_alternatives#Installation_from_non-Gentoo_LiveCDs) anyway. So - maybe drop it?

Regarding rescue tools offered by netboot.xyz, I have not tested them. It's possible that they require similar fixes. However, before working on them, I would like to confirm whether the general approach is OK.

Oh, and there seems to be a variable, ${netcfg}, in Debian-related iPXE files, but I can't find a place where it is set.
