### PR TITLE
remove cosmic

### DIFF
--- a/src/ubuntu.ipxe
+++ b/src/ubuntu.ipxe
@@ -11,7 +11,6 @@ clear ubuntu_version
 menu ${os} - ${arch_a} - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Latest Releases
 item disco ${space} ${os} 19.04 Disco Dingo
-item cosmic ${space} ${os} 18.10 Cosmic Cuttlefish
 item bionic ${space} ${os} 18.04 LTS Bionic Beaver
 item xenial ${space} ${os} 16.04 LTS Xenial Xerus
 item --gap Older Releases


### PR DESCRIPTION
Cosmic goe sout of support on 2019-07-18 according to https://en.wikipedia.org/wiki/Ubuntu_version_history#Table_of_versions