### PR TITLE
Tuning iPXE disks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: true
-dist: trusty
+dist: xenial
 language: c
 before_install:
 - openssl aes-256-cbc -K $encrypted_7d306b01dc1f_key -iv $encrypted_7d306b01dc1f_iv -in script/secrets.tar.enc -out script/secrets.tar -d
 - tar xvf script/secrets.tar -C script/
 - sudo apt-get update -qq
-- sudo apt-get install -qq binutils-dev binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu genisoimage liblzma-dev syslinux 
-- sudo pip install awscli tornado==4.5.3
+- sudo apt-get install -qq binutils-dev binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu genisoimage liblzma-dev syslinux isolinux
+- sudo pip install awscli tornado
 script:
 - "./script/prep-release.sh"
 deploy:

--- a/ipxe/local/crypto.h
+++ b/ipxe/local/crypto.h
@@ -1,0 +1,1 @@
+#undef OCSP_CHECK


### PR DESCRIPTION
* Switch to using xenial for iPXE builds
* Add workaround for arm64 builds on xenial
* Tune EFI ISO images so that they work on other platforms
  (https://github.com/antonym/netboot.xyz/pull/341)
* Disable OSCP checks as they can cause latency or connectivity
  issues