### PR TITLE
Adds Fedora CoreOS (Preview)

### DIFF
--- a/src/coreos.ipxe
+++ b/src/coreos.ipxe
@@ -1,0 +1,45 @@
+#!ipxe
+
+# Fedora CoreOS (Preview)
+# https://getfedora.org/coreos/
+
+goto ${menu}
+
+:coreos
+set os Fedora CoreOS
+isset ${install_device} || set install_device sda
+isset ${ignition_url} || set ignition_url skip
+menu ${os}
+item --gap ${os}:
+item beta ${space} ${os} 30
+item install_dev ${space} Set install device: ${install_device}
+item ignition_config ${space} Set ignition config url: ${ignition_url}
+choose --default ${menu} menu || goto coreos_exit
+echo ${cls}
+goto ${menu} ||
+goto coreos_exit
+
+:stable
+:beta
+:alpha
+set release ${menu}
+set base_url https://builds.coreos.fedoraproject.org/prod/streams/testing/builds
+set build_version 30.20190716.1
+kernel ${base_url}/${build_version}/x86_64/fedora-coreos-${build_version}-installer-kernel nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=${install_device} coreos.inst.ignition_url=${ignition_url} ${console} coreos.inst.image_url=${base_url}/${build_version}/x86_64/fedora-coreos-${build_version}-metal.raw.xz initrd=fedora-coreos-${build_version}-installer-initramfs.img
+initrd ${base_url}/${build_version}/x86_64/fedora-coreos-${build_version}-installer-initramfs.img
+boot
+goto coreos_exit
+
+:install_dev
+echo -n Please set desired install device:  && read install_device
+clear menu
+goto coreos
+
+:ignition_config
+echo -n Please set Ignition Configuration URL:  && read ignition_url
+clear menu
+goto coreos
+
+:coreos_exit
+clear menu
+exit 0

--- a/src/linux.ipxe
+++ b/src/linux.ipxe
@@ -16,6 +16,7 @@ item ubuntu ${space} Ubuntu
 item --gap All Others:
 item alpinelinux ${space} Alpine Linux
 item devuan ${space} Devuan
+item coreos ${space} Fedora CoreOS (Preview)
 item flatcar ${space} Flatcar
 item gentoo ${space} Gentoo Linux
 item ipfire ${space} IPFire


### PR DESCRIPTION
Adds initial Fedora CoreOS preview.  If ignition
is not specified, it will pass a skip to the configuration
which may not be entirely useful.  Recommend setting
an ignition configuration with the desired config.