### PR TITLE
Add Fedora silverblue

### DIFF
--- a/src/fedora.ipxe
+++ b/src/fedora.ipxe
@@ -27,6 +27,7 @@ item Everything ${ova} Everything
 item Server ${ova} Server
 item Workstation ${ova} Workstation
 item Atomic ${ova} Atomic
+iseq ${arch} x86_64 && item Silverblue ${ova} Silverblue ||
 isset ${sku_type} || choose sku_type || goto fedora
 set dir ${fedora_base_dir}/releases/${osversion}/${sku_type}/${arch}/os
 iseq ${sku_type} Atomic && iseq ${osversion} 29 && set dir fedora-alt/atomic/stable/Fedora-Atomic-29-20181025.1/AtomicHost/x86_64/os ||


### PR DESCRIPTION
Fedora silverblue is similar to Fedora atomic, but it is a workstation variant
using ostree. It was first made available from Fedora 29, for x86_64 only.