### PR TITLE
Drop reference to Fedora 28

### DIFF
--- a/src/fedora.ipxe
+++ b/src/fedora.ipxe
@@ -30,7 +30,6 @@ item Atomic ${ova} Atomic
 isset ${sku_type} || choose sku_type || goto fedora
 set dir ${fedora_base_dir}/releases/${osversion}/${sku_type}/${arch}/os
 iseq ${sku_type} Atomic && iseq ${osversion} 29 && set dir fedora-alt/atomic/stable/Fedora-Atomic-29-20181025.1/AtomicHost/x86_64/os ||
-iseq ${sku_type} Atomic && iseq ${osversion} 28 && set dir fedora-alt/atomic/stable/Fedora-Atomic-28-20180806.0/AtomicHost/x86_64/os ||
 set ova ${ova} ${sku_type}
 echo ${cls}
 goto boottype


### PR DESCRIPTION
The UI does not allow the user to select anything other than 29 or 30, and
Fedora 28 is no longer supported.