### PR TITLE
Add Fedora rawhide

### DIFF
--- a/src/fedora.ipxe
+++ b/src/fedora.ipxe
@@ -17,6 +17,7 @@ menu Fedora - ${arch} - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Latest Releases
 item 30 ${space} ${os} 30
 item 29 ${space} ${os} 29
+iseq ${arch} x86_64 && item rawhide ${space} ${os} rawhide ||
 isset ${osversion} || choose osversion || goto linux_menu
 set ova ${os} ${osversion}
 goto product_sku
@@ -29,6 +30,7 @@ item Workstation ${ova} Workstation
 item Atomic ${ova} Atomic
 isset ${sku_type} || choose sku_type || goto fedora
 set dir ${fedora_base_dir}/releases/${osversion}/${sku_type}/${arch}/os
+iseq ${osversion} rawhide && set dir ${fedora_base_dir}/development/${osversion}/${sku_type}/${arch}/os ||
 iseq ${sku_type} Atomic && iseq ${osversion} 29 && set dir fedora-alt/atomic/stable/Fedora-Atomic-29-20181025.1/AtomicHost/x86_64/os ||
 iseq ${sku_type} Atomic && iseq ${osversion} 28 && set dir fedora-alt/atomic/stable/Fedora-Atomic-28-20180806.0/AtomicHost/x86_64/os ||
 set ova ${ova} ${sku_type}
@@ -62,6 +64,7 @@ initrd http://${fedora_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:
 md5sum vmlinuz initrd.img
+iseq ${osversion} rawhide && goto skip_sigs ||
 iseq ${img_sigs_enabled} true && goto verify_sigs || goto skip_sigs
 :verify_sigs
 echo


### PR DESCRIPTION
Only available if image signature checks are disabled, and for x86_64.

Rawhide is updated every day, and is a perpetual release, similar to Debian unstable. As such, image validation is not feesable. I would still like to have rawhide available as an option to easily spin up a VM running it, the only question is the UI.

This change currently shows rawhide when image signature validation is disabled. Would you prefer if rawhide is always shown, and add a special case to disable image validation if rawhide is selected?