### PR TITLE
fix nameserver field for centos.ipxe

### DIFF
--- a/src/centos.ipxe
+++ b/src/centos.ipxe
@@ -2,8 +2,10 @@
 
 # CentOS Operating System
 # http://www.centos.org
-
-isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+# https://anaconda-installer.readthedocs.io/en/latest/boot-options.html
+# ip=<ip>::<gateway>:<netmask>:<hostname>:<interface>:none
+# nameserver is separated
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none nameserver=${dns}
 set ipparam BOOTIF=${netX/mac} ${ipparam}
 
 goto ${menu} ||


### PR DESCRIPTION
Hi,

the static DNS is defined by nameserver= not in the ip= field
I hope that syntax is ok!

Same change would be required for scientific.ipxe

Cheers

Tru
