### PR TITLE
Splits out nameserver to its own kernel option

### DIFF
--- a/src/centos.ipxe
+++ b/src/centos.ipxe
@@ -3,7 +3,7 @@
 # CentOS Operating System
 # http://www.centos.org
 
-isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none nameserver=${dns}
 set ipparam BOOTIF=${netX/mac} ${ipparam}
 
 goto ${menu} ||

--- a/src/debian.ipxe
+++ b/src/debian.ipxe
@@ -75,7 +75,7 @@ goto deb_boot
 :deb_boot
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel http://${debian_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
+kernel http://${debian_mirror}/${dir}/linux ${install_params} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
 initrd http://${debian_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/src/devuan.ipxe
+++ b/src/devuan.ipxe
@@ -61,7 +61,7 @@ goto devuan_boot
 :devuan_boot
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel http://${devuan_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
+kernel http://${devuan_mirror}/${dir}/linux ${install_params} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
 initrd http://${devuan_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/src/fedora.ipxe
+++ b/src/fedora.ipxe
@@ -3,7 +3,7 @@
 # Fedora Operating System
 # https://getfedora.org/
 
-isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none nameserver=${dns}
 set ipparam BOOTIF=${netX/mac} ${ipparam}
 
 goto ${menu} ||

--- a/src/opensuse.ipxe
+++ b/src/opensuse.ipxe
@@ -69,7 +69,7 @@ iseq ${version} tumbleweed && set dir ${version}/repo/oss ||
 imgfree
 kernel http://${opensuse_mirror}/${dir}/boot/x86_64/loader/linux
 initrd http://${opensuse_mirror}/${dir}/boot/x86_64/loader/initrd
-imgargs linux ${netsetup} install=http://${opensuse_mirror}/${dir} ${params} ${netcfg} ${console} initrd=initrd
+imgargs linux ${netsetup} install=http://${opensuse_mirror}/${dir} ${params} ${console} initrd=initrd
 echo
 echo MD5sums:
 md5sum linux initrd

--- a/src/rhel.ipxe
+++ b/src/rhel.ipxe
@@ -3,7 +3,7 @@
 # Redhat Enterprise Linux (RHEL)
 # https://www.redhat.com
 
-isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none nameserver=${dns}
 set ipparam BOOTIF=${netX/mac} ${ipparam}
 
 set rhel_arch x86_64

--- a/src/scientific.ipxe
+++ b/src/scientific.ipxe
@@ -3,7 +3,7 @@
 # Scientific Linux Operating System
 # https://www.scientificlinux.org/
 
-isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none:${dns}
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none nameserver=${dns}
 set ipparam BOOTIF=${netX/mac} ${ipparam}
 
 goto ${menu} ||
@@ -50,7 +50,7 @@ goto bootos_images
 
 :bootos_images
 imgfree
-kernel http://ftp1.scientificlinux.org/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${netcfg} ${console} ${ipparam}
+kernel http://ftp1.scientificlinux.org/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${console} ${ipparam}
 initrd http://ftp1.scientificlinux.org/${dir}/images/pxeboot/initrd.img
 boot
 goto linux_menu

--- a/src/ubuntu.ipxe
+++ b/src/ubuntu.ipxe
@@ -61,7 +61,7 @@ goto deb_boot
 :deb_boot
 set dir ${dir}${menu}-installer/${arch_a}
 imgfree
-kernel http://${ubuntu_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
+kernel http://${ubuntu_mirror}/${dir}/linux ${install_params} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
 initrd http://${ubuntu_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:


### PR DESCRIPTION
Moves nameserver out of ip option to nameserver
option on anaconda style installers, also removes
unused netcfg options.

Fixes https://github.com/antonym/netboot.xyz/issues/360