### PR TITLE
bump NixOS to 19.09, drop 18.09

### DIFF
--- a/src/nixos.ipxe
+++ b/src/nixos.ipxe
@@ -6,12 +6,12 @@
 set os Nixos Linux
 menu ${os}
 item --gap Official Releases
+item 19.03 ${space} Nixos 19.09
 item 19.03 ${space} Nixos 19.03
-item 18.09 ${space} Nixos 18.09
 item unstable ${space} Nixos unstable
 choose version || goto nixos_exit
+iseq ${version} 19.09 && set link https://hydra.nixos.org/job/nixos/release-19.09/nixos.netboot.x86_64-linux/latest-finished/download/netboot.ipxe ||
 iseq ${version} 19.03 && set link https://hydra.nixos.org/job/nixos/release-19.03/nixos.netboot.x86_64-linux/latest-finished/download/netboot.ipxe ||
-iseq ${version} 18.09 && set link https://hydra.nixos.org/job/nixos/release-18.09/nixos.netboot.x86_64-linux/latest-finished/download/netboot.ipxe ||
 iseq ${version} unstable && set link https://hydra.nixos.org/job/nixos/trunk-combined/nixos.netboot.x86_64-linux/latest-finished/download/netboot.ipxe ||
 chain ${link}
 goto nixos_exit


### PR DESCRIPTION
NixOS 19.09 was released yesterday, also dropping the old release now, since it is no longer maintained. 