### PR TITLE
Start of Defining a localized version TFTP boot parameter

### DIFF
--- a/ipxe/disks/netboot.xyz
+++ b/ipxe/disks/netboot.xyz
@@ -5,6 +5,7 @@ set boldoff ${esc:string}[22m
 set fg_gre ${esc:string}[32m
 set fg_cya ${esc:string}[36m
 set fg_whi ${esc:string}[37m
+set TFTP_ERR Local TFTP failed... attempting remote HTTPS
 set HTTPS_ERR HTTPS appears to have failed... attempting HTTP
 set HTTP_ERR HTTP has failed, localbooting...
 set version 1.04
@@ -44,6 +45,7 @@ echo Attempting chainload of netboot.xyz...
 goto menu || goto failsafe
 
 :menu
+chain --autofree tftp://${next-server}/menu.ipxe || echo ${TFTP_ERR}
 set conn_type https
 chain --autofree https://boot.netboot.xyz/menu.ipxe || echo ${HTTPS_ERR}
 sleep 5


### PR DESCRIPTION
Hello from the Linuxserver.io team. First off wanted to let you know we are pushing a simple image with your pxe/efi bins in it with a TFTP server: 
https://hub.docker.com/r/linuxserver/netbootxyz
We also plan on putting a blog entry up as internally team members have found it very useful inside of their VM environments. 

I would like to get the ball rolling on building logic that allows users to self host not only menu files but also kernel/initrd/iso files and serve them via tftp/http. I am only assuming you are interested in this based on https://github.com/antonym/netboot.xyz/issues/26 . 

For right now this PR is only to allow local ipxe files to be served from a TFTP server, and is meant to be as unobtrusive as possible. 

Downstream I am working on the logic to convert this image into something more local starting with the menus: 
https://github.com/linuxserver/docker-netbootxyz/tree/local

Outside of this PR I had some thoughts on how this could be achieved, but it is going to involve some pretty heavy re-writes of the ipxe files where the endpoints are defined along with templating I did not want to go off half cocked without gauging your interest. 
I have experience with all CM platforms including Ansible so if you want to start Jinja templating the files based on local/remote build parameters I am game.

Let me know what you think. 