### PR TITLE
Generate packet x86_64 efi disk

### DIFF
--- a/ipxe/disks/netboot.xyz-packet
+++ b/ipxe/disks/netboot.xyz-packet
@@ -12,7 +12,7 @@ set version 1.04
 set ipxe_cloud_config packet
 
 :start
-echo ${bold}${fg_gre}netboot.xyz ${fg_whi}v${version} for ${fg_red}packet.net${fg_whi}${boldoff}
+echo ${bold}${fg_gre}netboot.xyz ${fg_whi}v${version} for ${fg_red}packet.com${fg_whi}${boldoff}
 prompt --key m --timeout 4000 Hit the ${bold}m${boldoff} key to open failsafe menu... && goto failsafe || goto dhcp
 
 :dhcp

--- a/script/prep-release.sh
+++ b/script/prep-release.sh
@@ -38,7 +38,7 @@ cp -f bin/ipxe.usb disk.raw
 tar Sczvf netboot.xyz-gce.tar.gz disk.raw
 mv netboot.xyz-gce.tar.gz ../../build/ipxe/netboot.xyz-gce.tar.gz
 
-# generate netboot.xyz-packet iPXE disk
+# generate netboot.xyz-packet legacy iPXE disk
 make bin/undionly.kpxe \
 EMBED=../../ipxe/disks/netboot.xyz-packet TRUST=ca-ipxe-org.crt,ca-netboot-xyz.crt
 mv bin/undionly.kpxe ../../build/ipxe/netboot.xyz-packet.kpxe
@@ -56,6 +56,11 @@ mcopy -i efi_tmp/ipxe.img bin-x86_64-efi/ipxe.efi ::efi/boot/bootx64.efi
 genisoimage -o ipxe.eiso -eltorito-alt-boot -e ipxe.img -no-emul-boot efi_tmp
 mv bin-x86_64-efi/ipxe.efi ../../build/ipxe/netboot.xyz.efi
 mv ipxe.eiso ../../build/ipxe/netboot.xyz-efi.iso
+
+# generate netboot.xyz-packet efi iPXE disk
+make bin-x86_64-efi/ipxe.efi \
+EMBED=../../ipxe/disks/netboot.xyz-packet TRUST=ca-ipxe-org.crt,ca-netboot-xyz.crt
+mv bin-x86_64-efi/ipxe.efi ../../build/ipxe/netboot.xyz-packet.efi
 
 # iPXE workaround
 # http://lists.ipxe.org/pipermail/ipxe-devel/2018-August/006254.html

--- a/src/boot.cfg
+++ b/src/boot.cfg
@@ -117,7 +117,7 @@ goto clouds_end
 
 :packet_x86_64
 set console console=ttyS1,115200n8
-set ipxe_disk netboot.xyz-packet.kpxe
+iseq ${platform} efi && set ipxe_disk netboot.xyz-packet.efi || set ipxe_disk netboot.xyz-packet.kpxe
 set menu_freedos 0
 set menu_windows 0
 set menu_utils 0


### PR DESCRIPTION
For x86_64 systems with UEFI, use the efi disk,
else leverage the legacy kpxe disk

Fixes https://github.com/antonym/netboot.xyz/issues/383