### PR TITLE
adding tftp option to boot menu by default to support local menus

### DIFF
--- a/roles/netbootxyz/templates/disks/ipxe-bootloader.j2
+++ b/roles/netbootxyz/templates/disks/ipxe-bootloader.j2
@@ -19,6 +19,8 @@ prompt --key m --timeout 4000 Hit the ${bold}m${boldoff} key to open failsafe me
 :dhcp
 echo
 dhcp || goto netconfig
+isset ${next-server} && iseq ${filename} netboot.xyz.kpxe && goto tftpmenu
+isset ${next-server} && iseq ${filename} netboot.xyz.efi && goto tftpmenu
 goto menu
 
 :failsafe
@@ -46,8 +48,10 @@ ifopen net${net}
 echo Attempting chainload of ${boot_domain}...
 goto menu || goto failsafe
 
+:tftpmenu
+chain --autofree tftp://${next-server}/menu.ipxe || echo ${TFTP_ERR} && goto menu
+
 :menu
-chain --autofree tftp://${next-server}/menu.ipxe || echo ${TFTP_ERR}
 set conn_type https
 chain --autofree https://${boot_domain}/menu.ipxe || echo ${HTTPS_ERR}
 sleep 5

--- a/roles/netbootxyz/templates/disks/ipxe-bootloader.j2
+++ b/roles/netbootxyz/templates/disks/ipxe-bootloader.j2
@@ -5,6 +5,7 @@ set boldoff ${esc:string}[22m
 set fg_gre ${esc:string}[32m
 set fg_cya ${esc:string}[36m
 set fg_whi ${esc:string}[37m
+set TFTP_ERR Local TFTP failed... attempting remote HTTPS 
 set HTTPS_ERR HTTPS appears to have failed... attempting HTTP
 set HTTP_ERR HTTP has failed, localbooting...
 set boot_domain {{ boot_domain }}
@@ -46,6 +47,7 @@ echo Attempting chainload of ${boot_domain}...
 goto menu || goto failsafe
 
 :menu
+chain --autofree tftp://${next-server}/menu.ipxe || echo ${TFTP_ERR}
 set conn_type https
 chain --autofree https://${boot_domain}/menu.ipxe || echo ${HTTPS_ERR}
 sleep 5


### PR DESCRIPTION
Up for discussion once again, I use this heavily for a local testing env and am currently building custom disks. 
The TFTP option fail on non availability of the file or timeout is so fast you can barely see the error message. 