### PR TITLE
adding basic docker builder

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -26,6 +26,6 @@ RUN \
 FROM alpine:3.10
 
 COPY --from=builder /var/www/html/ /mnt/
-COPY docker-root/ /
+COPY docker-build-root/ /
 
 ENTRYPOINT [ "/dumper.sh" ]

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -1,0 +1,31 @@
+FROM ubuntu:bionic as builder
+
+RUN \
+ echo "**** install deps ****" && \
+ apt-get update && \
+ apt-get install -y \
+	ansible \
+	apache2  \
+	build-essential \
+	genisoimage \
+	git \
+	liblzma-dev \
+	python-minimal \
+	python-yaml \
+	syslinux
+
+# repo for build
+COPY . /ansible
+
+RUN \
+ echo "**** running ansible ****" && \
+ cd /ansible && \
+ ansible-playbook -i inventory/all netbootxyz.yml
+
+# runtime stage
+FROM alpine:3.10
+
+COPY --from=builder /var/www/html/ /mnt/
+COPY docker-root/ /
+
+ENTRYPOINT [ "/dumper.sh" ]

--- a/README.md
+++ b/README.md
@@ -13,13 +13,32 @@ The source files are now templates in order to make things a bit easier to gener
 
 This is a seperate repo for now but will more than likely roll into the existing repo.
 
+# Building locally
+
+## With Ansible
+
 To generate, run:
 
 ```
 ansible-playbook -i inventory/all netbootxyz.yml
 ```
 
-It'll handle source generation as well as ipxe disk generation with the users settings.  The disk generation was worked on a while back so it needs work to catch it up to the existing state of netboot.xyz.
+The build output will be located in /var/www/html on Debian OSs.
+
+## With Docker
+
+```
+docker build -t localbuild -f Dockerfile-build .
+docker run --rm -it -v $(pwd):/buildout localbuild
+```
+
+The build output will be in the generated folder `buildout`
+
+## Local Overides
+
+Ansible will handle source generation as well as ipxe disk generation with your settings.  The disk generation was worked on a while back so it needs work to catch it up to the existing state of netboot.xyz.
 
 If you want to override the defaults, you can put overrides in user_overrides.yml.  See file for examples.
+
+Also note many user customizations are located in the boot.cfg file for the IPXE menus. A high level of customization can be achieved using our stock build output and hosting this along with the menus locally. 
 

--- a/docker-build-root/dumper.sh
+++ b/docker-build-root/dumper.sh
@@ -1,0 +1,20 @@
+#! /bin/sh
+
+# check for dump dir
+if [ -d /buildout ]; then
+  # if there are no files in that directory use 777 perms as root
+  if [ `find /buildout -prune -empty 2>/dev/null` ]; then
+    /bin/mkdir -p /buildout/buildout
+    /bin/cp -r /mnt/* /buildout/buildout/
+    /bin/chmod 777 -R /buildout/buildout
+  # match the ownership of the first file we see
+  else
+    PERMS=`/usr/bin/find /buildout/* -print -quit |xargs stat -c "%u:%g"`
+    /bin/mkdir -p /buildout/buildout
+    /bin/cp -r /mnt/* /buildout/buildout/
+    /bin/chown $PERMS -R /buildout/buildout
+  fi
+else
+  /bin/echo "/buildout not found exiting"  
+  exit 1
+fi  


### PR DESCRIPTION
We can do a self contained container for running an NGINX webserver/tftp-hpa but this is just a starter builder with a baked in dumper script. 