### PR TITLE
Adds dynamic live debian and ubuntu menus

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -4,7 +4,9 @@
 site_name: netboot.xyz
 boot_domain: boot.netboot.xyz
 boot_version: 1.04
+boot_timeout: 300000
 
+time_server: "0.pool.ntp.org"
 sigs_enabled: false
 img_sigs_enabled: false
 sigs_location: "http://${boot_domain}/sigs/"
@@ -81,6 +83,8 @@ releases:
     menu: "linux"    
     versions:
       stable:
+        - name: "10.0 (buster)"
+          code_name: "buster"
         - name: "9.0 (stretch)"
           code_name: "stretch"
         - name: "8.0 (jessie)"
@@ -88,8 +92,8 @@ releases:
         - name: "7.0 (jessie)"
           code_name: "wheezy"
       testing:
-        - name: "buster (testing)"
-          code_name: "buster"
+        - name: "bullseye (testing)"
+          code_name: "bullseye"
         - name: "sid (unstable)"
           code_name: "sid"
   devuan:

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -25,14 +25,6 @@ set ipxe_disk netboot.xyz-undionly.kpxe
 # set location of custom netboot.xyz live assets
 set live_endpoint {{ live_endpoint }}
 
-##############################
-# netboot-xyz hosted endpoints
-##############################
-
-{% for key, value in endpoints.iteritems() %}
-set {{ key }} {{ value['path'] }}
-{% endfor %}
-
 #################################################
 # determine architectures and enable menu options
 #################################################

--- a/roles/netbootxyz/templates/menu/live-debian.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-debian.ipxe.j2
@@ -3,40 +3,57 @@
 goto ${menu} ||
 
 :live_menu
-menu Live Debian Default - Current Arch [ ${arch} ]
+set os Debian Live
+menu ${os} - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
-item --gap Live Debian
+item --gap ${os} Versions
+item buster ${space} ${os} 10 (buster)
+choose live_version || goto live_exit
+menu ${os} ${live_version}
+item --gap ${os} Flavors
+goto ${live_version}
+
+:stretch
 {% for key, value in endpoints.items() | sort %}
-{% if value.os == "debian" and 'squash' in key %}
+{% if value.os == "debian" and 'squash' in key and value.version == "9" %}
 item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
 {% endif %}
 {% endfor %}
-choose menu || goto live_exit
+goto flavor_select
+
+:buster
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "debian" and 'squash' in key and value.version == "10" %}
+item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
+{% endif %}
+{% endfor %}
+goto flavor_select
+
+:flavor_select
+choose flavor || goto live_menu
 echo ${cls}
-goto ${menu} ||
-iseq ${sigs_enabled} true && goto verify_sigs || goto change_menu
+goto ${flavor} ||
 
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "debian" and 'squash' in key %}
 {% set kernel_name = value.kernel %}
 :{{ key }}
-imgfree
-set fetch_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
 {% for key, value in endpoints.items() | sort %}
 {% if key == kernel_name %}
-kernel ${live_endpoint}{{ value.path }}vmlinuz boot=live fetch=${fetch_url} initrd=initrd
-initrd ${live_endpoint}{{ value.path }}initrd
-boot
+set kernel_url ${live_endpoint}{{ value.path }}
+goto boot
 {% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}
 
-:change_menu
-chain ${menu}.ipxe || goto error
-goto live_menu
+:boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
 
 :live_exit
 clear menu
 exit 0
-

--- a/roles/netbootxyz/templates/menu/live-ubuntu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-ubuntu.ipxe.j2
@@ -3,38 +3,57 @@
 goto ${menu} ||
 
 :live_menu
-menu Live Ubuntu Default (Unity) - Current Arch [ ${arch} ]
+set os Ubuntu Live
+menu ${os} - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
-item --gap Live Ubuntu Default (Unity)
+item --gap ${os} Versions
+item bionic ${space} ${os} 18.04
+item eoan ${space} ${os} 19.10
+choose live_version || goto live_exit
+menu ${os} ${live_version}
+item --gap ${os} Flavors
+goto ${live_version}
+
+:bionic
 {% for key, value in endpoints.items() | sort %}
-{% if value.os == "ubuntu" and 'squash' in key %}
+{% if value.os == "ubuntu" and 'squash' in key and value.version == "18.04" %}
 item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
 {% endif %}
 {% endfor %}
-choose menu || goto live_exit
+goto flavor_select
+
+:eoan
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "ubuntu" and 'squash' in key and value.version == "19.10" %}
+item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
+{% endif %}
+{% endfor %}
+goto flavor_select
+
+:flavor_select
+choose flavor || goto live_menu
 echo ${cls}
-goto ${menu} ||
-iseq ${sigs_enabled} true && goto verify_sigs || goto change_menu
+goto ${flavor} ||
 
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "ubuntu" and 'squash' in key %}
 {% set kernel_name = value.kernel %}
 :{{ key }}
-imgfree
-set fetch_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
 {% for key, value in endpoints.items() | sort %}
 {% if key == kernel_name %}
-kernel ${live_endpoint}{{ value.path }}vmlinuz boot=casper netboot=http fetch=${fetch_url} initrd=initrd
-initrd ${live_endpoint}{{ value.path }}initrd
-boot
+set kernel_url ${live_endpoint}{{ value.path }}
+goto boot
 {% endif %}
 {% endfor %}
 {% endif %}
 {% endfor %}
 
-:change_menu
-chain ${menu}.ipxe || goto error
-goto live_menu
+:boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
 
 :live_exit
 clear menu

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -7,7 +7,6 @@ menu Live Boot Distributions - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 item --gap Live Boot Distributions
 item live-debian ${space} Debian Live
-item live-manjaro ${space} Manjaro Live
 item live-ubuntu ${space} Ubuntu Live
 choose menu || goto live_exit
 echo ${cls}

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -2,6 +2,7 @@
 
 :start
 chain --autofree boot.cfg ||
+ntp {{ time_server }}
 iseq ${cls} serial && goto ignore_cls ||
 set cls:hex 1b:5b:4a  # ANSI clear screen sequence - "^[[J"
 set cls ${cls:string}
@@ -57,7 +58,7 @@ item sig_check ${space} netboot.xyz [ enabled: ${sigs_enabled} ]
 item img_sigs_check ${space} Images [ enabled: ${img_sigs_enabled} ]
 isset ${github_user} && item --gap Custom Menu: ||
 isset ${github_user} && item nbxyz-custom ${space} ${github_user}'s Custom Menu ||
-isset ${menu} && set timeout 0 || set timeout 300000
+isset ${menu} && set timeout 0 || set timeout {{ boot_timeout }}
 choose --timeout ${timeout} --default ${menu} menu || goto local
 echo ${cls}
 goto ${menu} ||


### PR DESCRIPTION
Still requires the versions to be set but we can probably
get those automatically generated too at some point

Makes boot timeout configurable
Adds configurable NTP to ensure time is correct when using HTTPS