### PR TITLE
Build logic for dev branch RC and Live

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ jobs:
           upload-dir: $TRAVIS_COMMIT
           region: us-west-2
           skip_cleanup: true
+          on:
+            branch: development
       after_deploy:
         - ./script/message dev-push
     - stage: pull-request

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ jobs:
   include:
     - stage: development
       if: branch = development AND tag IS blank AND type != pull_request
-      before_install:
-        - ./script/pre_install
       script:
         - ./script/build_release dev
       after_failure:
@@ -40,6 +38,8 @@ jobs:
         - echo test
     - stage: release
       if: branch = master AND type != pull_request
+      before_install:
+        - ./script/pre_install
       script:
         - echo test
       deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,38 +24,96 @@ jobs:
           bucket: $BUCKET_DEV
           local_dir: s3out
           upload-dir: $TRAVIS_COMMIT
-          region: us-west-2
           skip_cleanup: true
           on:
             branch: development
       after_deploy:
         - ./script/message dev-push
+
+
     - stage: pull-request
       if: type = pull_request
       script:
-        - echo test
+        - ./script/build_release pr
+
+
     - stage: release-canidate
       if: branch = development AND tag IS present AND type != pull_request
-      script:
-        - echo test
-    - stage: release
-      if: branch = master AND type != pull_request
       before_install:
         - ./script/pre_install
       script:
-        - echo test
+        - ./script/build_release rc
+      after_failure:
+        - ./script/message failure
       deploy:
         - provider: s3
           access_key_id: $AWS_ACCESS_KEY_ID
           secret_access_key: $AWS_SECRET_ACCESS_KEY
           bucket: $BUCKET_LIVE
-          local_dir: s3out
+          local_dir: s3out-latest
+          upload-dir: rc
           skip_cleanup: true
+          on:
+            branch: development
+        - provider: s3
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $BUCKET_LIVE
+          local_dir: s3out
+          upload-dir: $TRAVIS_TAG
+          skip_cleanup: true
+          on:
+            branch: development
+        - provider: releases
+          api_key: $GITHUB_TOKEN
+          file_glob: true
+          file: githubout/*
+          prerelease: true
+          skip_cleanup: true
+          on:
+            branch: development
+      after_deploy:
+        - aws configure set preview.cloudfront true
+        - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DIST_ID_BOOT --paths "rc/*" "rc/ipxe/*"
+        - ./script/message rc-push
+
+    - stage: release
+      if: branch = master AND type != pull_request
+      before_install:
+        - ./script/pre_install
+      script:
+        - ./script/build_release release
+      after_failure:
+        - ./script/message failure
+      before_deploy:
+        - export RELEASE_TAG=$(cat version.txt)
+        - git tag ${RELEASE_TAG}
+      deploy:
+        - provider: s3
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $BUCKET_LIVE
+          local_dir: s3out-latest
+          skip_cleanup: true
+          on:
+            branch: master
+        - provider: s3
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $BUCKET_LIVE
+          local_dir: s3out
+          upload-dir: $RELEASE_TAG
+          skip_cleanup: true
+          on:
+            branch: master
         - provider: releases
           api_key: $GITHUB_TOKEN
           file_glob: true
           file: githubout/*
           skip_cleanup: true
+          on:
+            branch: development
       after_deploy:
         - aws configure set preview.cloudfront true
-        - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DIST_ID_BOOT --paths "/*"
+        - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DIST_ID_BOOT --paths "/*" "/ipxe/*"
+        - ./script/message live-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+sudo: true
+
+language: bash
+
+services:
+  - docker
+
+env:
+  global:
+    - DEBIAN_FRONTEND="noninteractive"
+
+jobs:
+  include:
+    - stage: development
+      if: branch = development AND tag IS blank AND type != pull_request
+      before_install:
+        - ./script/pre_install
+      script:
+        - ./script/build_release dev
+      after_failure:
+        - ./script/message failure
+      deploy:
+        - provider: s3
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $BUCKET_DEV
+          local_dir: s3out
+          upload-dir: $TRAVIS_COMMIT
+          region: us-west-2
+          skip_cleanup: true
+      after_deploy:
+        - ./script/message dev-push
+    - stage: pull-request
+      if: type = pull_request
+      script:
+        - echo test
+    - stage: release-canidate
+      if: branch = development AND tag IS present AND type != pull_request
+      script:
+        - echo test
+    - stage: release
+      if: branch = master AND type != pull_request
+      script:
+        - echo test
+      deploy:
+        - provider: s3
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $BUCKET_LIVE
+          local_dir: s3out
+          skip_cleanup: true
+        - provider: releases
+          api_key: $GITHUB_TOKEN
+          file_glob: true
+          file: githubout/*
+          skip_cleanup: true
+      after_deploy:
+        - aws configure set preview.cloudfront true
+        - aws cloudfront create-invalidation --distribution-id $CLOUDFRONT_DIST_ID_BOOT --paths "/*"

--- a/script/build_release
+++ b/script/build_release
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+TYPE=$1
+
+# Set boot domain
+if [[ "${TYPE}" == "dev" ]]; then
+  BOOT_DOMAIN="${BUCKET_DEV}.s3-us-west-2.amazonaws.com/${TRAVIS_COMMIT}"
+fi
+sed -i \
+  "/^#boot_domain/c\boot_domain: ${BOOT_DOMAIN}" \
+  user_overrides.yml
+
+# Build release
+docker build -t localbuild -f Dockerfile-build .
+docker run --rm -it -v $(pwd):/buildout localbuild
+
+# Generate folder outputs
+mkdir -p s3out
+cp -r buildout/* s3out/
+cp script/index.html s3out/
+mkdir -p githubout
+mv buildout/ipxe/* githubout/
+cd buildout
+rm -Rf ipxe
+tar -czf menus.tar.gz *
+mv menus.tar.gz ../githubout
+cd ..
+

--- a/script/build_release
+++ b/script/build_release
@@ -5,6 +5,12 @@ TYPE=$1
 # Set boot domain
 if [[ "${TYPE}" == "dev" ]]; then
   BOOT_DOMAIN="${BUCKET_DEV}.s3-us-west-2.amazonaws.com/${TRAVIS_COMMIT}"
+elif [[ "${TYPE}" == "pr" ]]; then
+  BOOT_DOMAIN="test.com"
+elif [[ "${TYPE}" == "rc" ]]; then
+  BOOT_DOMAIN="boot.netboot.xyz/${TRAVIS_TAG}"
+elif [[ "${TYPE}" == "release" ]]; then
+  BOOT_DOMAIN="boot.netboot.xyz/$(cat verion.txt)"
 fi
 sed -i \
   "/^#boot_domain/c\boot_domain: ${BOOT_DOMAIN}" \
@@ -26,3 +32,25 @@ tar -czf menus.tar.gz *
 mv menus.tar.gz ../githubout
 cd ..
 
+
+# Latest style endpoints for RC and Live
+if [[ "${TYPE}" == "release" ]] || [[ "${TYPE}" == "rc" ]]; then
+  rm -Rf buildout/
+  if [[ "${TYPE}" == "release" ]]; then
+    sed -i \
+      "/^boot_domain/c\boot_domain: boot.netboot.xyz" \
+      user_overrides.yml
+    docker build -t localbuild -f Dockerfile-build .
+    docker run --rm -it -v $(pwd):/buildout localbuild
+  fi
+  if [[ "${TYPE}" == "rc" ]]; then
+    sed -i \
+      "/^boot_domain/c\boot_domain: boot.netboot.xyz/rc" \
+      user_overrides.yml
+    docker build -t localbuild -f Dockerfile-build .
+    docker run --rm -it -v $(pwd):/buildout localbuild
+  fi
+  mkdir -p s3out-latest
+  cp -r buildout/* s3out-latest/
+  cp script/index.html s3out-latest/
+fi

--- a/script/index.html
+++ b/script/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>Netboot.xyz BootLoaders</title>
+  </head>
+  <body>
+  <a href="ipxe/netboot.xyz.iso">netboot.xyz.iso</a>
+  <a href="ipxe/netboot.xyz-efi.iso">netboot.xyz-efi.iso</a>
+  <a href="ipxe/netboot.xyz.dsk">netboot.xyz.dsk</a>
+  <a href="ipxe/netboot.xyz.usb">netboot.xyz.usb</a>
+  <a href="ipxe/netboot.xyz.lkrn">netboot.xyz.lkrn</a>
+  <a href="ipxe/netboot.xyz.kpxe">netboot.xyz.kpxe</a>
+  <a href="ipxe/netboot.xyz-undionly.kpxe">netboot.xyz-undionly.kpxe</a>
+  <a href="ipxe/netboot.xyz.efi">netboot.xyz.efi</a>
+  </body>
+</html>

--- a/script/index.html
+++ b/script/index.html
@@ -4,13 +4,13 @@
     <title>Netboot.xyz BootLoaders</title>
   </head>
   <body>
-  <a href="ipxe/netboot.xyz.iso">netboot.xyz.iso</a>
-  <a href="ipxe/netboot.xyz-efi.iso">netboot.xyz-efi.iso</a>
-  <a href="ipxe/netboot.xyz.dsk">netboot.xyz.dsk</a>
-  <a href="ipxe/netboot.xyz.usb">netboot.xyz.usb</a>
-  <a href="ipxe/netboot.xyz.lkrn">netboot.xyz.lkrn</a>
-  <a href="ipxe/netboot.xyz.kpxe">netboot.xyz.kpxe</a>
-  <a href="ipxe/netboot.xyz-undionly.kpxe">netboot.xyz-undionly.kpxe</a>
-  <a href="ipxe/netboot.xyz.efi">netboot.xyz.efi</a>
+  <a href="ipxe/netboot.xyz.iso">netboot.xyz.iso</a><br>
+  <a href="ipxe/netboot.xyz-efi.iso">netboot.xyz-efi.iso</a><br>
+  <a href="ipxe/netboot.xyz.dsk">netboot.xyz.dsk</a><br>
+  <a href="ipxe/netboot.xyz.usb">netboot.xyz.usb</a><br>
+  <a href="ipxe/netboot.xyz.lkrn">netboot.xyz.lkrn</a><br>
+  <a href="ipxe/netboot.xyz.kpxe">netboot.xyz.kpxe</a><br>
+  <a href="ipxe/netboot.xyz-undionly.kpxe">netboot.xyz-undionly.kpxe</a><br>
+  <a href="ipxe/netboot.xyz.efi">netboot.xyz.efi</a><br>
   </body>
 </html>

--- a/script/message
+++ b/script/message
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+TYPE=$1
+
+if [ "${TYPE}" == "dev-push" ]; then
+  BOOT_URL="https://${BUCKET_DEV}.s3-us-west-2.amazonaws.com/${TRAVIS_COMMIT}/index.html"
+fi
+
+# send status to discord
+if [ "${TYPE}" == "failure" ]; then
+  curl -X POST --data \
+  '{
+    "avatar_url": "https://avatars.io/twitter/travisci",
+    "embeds": [
+      {
+        "color": 16711680,
+        "description": "__**Failed to Build**__ \n**Build:**  '${TRAVIS_BUILD_WEB_URL}'\n**External Version:**  '${EXTERNAL_VERSION}'\n**Status:**  Failure\n**Change:** https://github.com/netbootxyz/netboot.xyz/commit/'${TRAVIS_COMMIT}'\n"
+      }
+    ],
+    "username": "Travis CI"
+  }' \
+  ${DISCORD_HOOK_URL}
+else
+  curl -X POST --data \
+  '{
+    "avatar_url": "https://avatars.io/twitter/travisci",
+    "embeds": [
+      {
+        "color": 1681177,
+        "description": "__**Boot Menu Published**__ \n**Files:** '${BOOT_URL}' \n**Build:**  '${TRAVIS_BUILD_WEB_URL}'\n**External Version:**  '${EXTERNAL_VERSION}'\n**Change:** https://github.com/netbootxyz/netboot.xyz/commit/'${TRAVIS_COMMIT}'\n"
+      }
+    ],
+    "username": "Travis CI"
+  }' \
+  ${DISCORD_HOOK_URL}
+fi

--- a/script/message
+++ b/script/message
@@ -3,8 +3,13 @@
 TYPE=$1
 
 if [ "${TYPE}" == "dev-push" ]; then
-  BOOT_URL="https://${BUCKET_DEV}.s3-us-west-2.amazonaws.com/${TRAVIS_COMMIT}/index.html"
+  BOOT_URL="https://${BUCKET_DEV}.s3-us-east-1.amazonaws.com/${TRAVIS_COMMIT}/index.html"
+elif [ "${TYPE}" == "rc-push" ]; then
+  BOOT_URL="https://boot.netboot.xyz/${TRAVIS_TAG}/index.html"
+elif [ "${TYPE}" == "live-push" ]; then
+  BOOT_URL="https://boot.netboot.xyz/$(cat version.txt)/index.html"
 fi
+
 
 # send status to discord
 if [ "${TYPE}" == "failure" ]; then
@@ -14,7 +19,7 @@ if [ "${TYPE}" == "failure" ]; then
     "embeds": [
       {
         "color": 16711680,
-        "description": "__**Failed to Build**__ \n**Build:**  '${TRAVIS_BUILD_WEB_URL}'\n**External Version:**  '${EXTERNAL_VERSION}'\n**Status:**  Failure\n**Change:** https://github.com/netbootxyz/netboot.xyz/commit/'${TRAVIS_COMMIT}'\n"
+        "description": "__**Failed to Build**__ \n**Build:**  '${TRAVIS_BUILD_WEB_URL}'\n**Status:**  Failure\n**Change:** https://github.com/netbootxyz/netboot.xyz/commit/'${TRAVIS_COMMIT}'\n"
       }
     ],
     "username": "Travis CI"
@@ -27,7 +32,7 @@ else
     "embeds": [
       {
         "color": 1681177,
-        "description": "__**Boot Menu Published**__ \n**Files:** '${BOOT_URL}' \n**Build:**  '${TRAVIS_BUILD_WEB_URL}'\n**External Version:**  '${EXTERNAL_VERSION}'\n**Change:** https://github.com/netbootxyz/netboot.xyz/commit/'${TRAVIS_COMMIT}'\n"
+        "description": "__**Boot Menu Published**__ \n**Files:** '${BOOT_URL}' \n**Build:**  '${TRAVIS_BUILD_WEB_URL}'\n**Change:** https://github.com/netbootxyz/netboot.xyz/commit/'${TRAVIS_COMMIT}'\n"
       }
     ],
     "username": "Travis CI"

--- a/script/pre_install
+++ b/script/pre_install
@@ -2,4 +2,4 @@
 
 # Install aws cli
 
-pip install awscli tornado
+pip install --user awscli tornado

--- a/script/pre_install
+++ b/script/pre_install
@@ -1,5 +1,4 @@
 #!/bin/bash
 
 # Install aws cli
-
-pip install --user awscli tornado
+sudo pip install awscli tornado

--- a/script/pre_install
+++ b/script/pre_install
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# Install aws cli
+
+pip install awscli tornado


### PR DESCRIPTION
Secrets that need to be set for the repo: 

- BUCKET_DEV- bucket to use for dev output that is built on commit
- BUCKET_LIVE- bucket linked up with boot.netboot.xyz domain via cloudfront
- AWS_ACCESS_KEY_ID- IAM user with r/w to s3 and invalidtion access to cloudfront
- AWS_SECRET_ACCESS_KEY- IAM key with r/w to s3 and invalidtion access to cloudfront
- CLOUDFRONT_DIST_ID_BOOT- CF distribution id
- GITHUB_TOKEN- token for the ci user for publishing pre-releases and releases
- DISCORD_HOOK_URL- Hook for pinging in build URLs to discord (this is set on the asset repos)

The general idea here is we have 4 different build scenarios: 
* Commit to dev- Stuff is built and pushed to a long ugly S3 url so we can download the booters and test it out
* Pull Request- Build only with no secrets for basic checkmark on a PR
* Release candidate- when we tag development to freeze it at a certain commit this tag will push to an rc subfolder and to a subfolder named after the tag on the live endpoint boot.netboot.xyz/rc. This also pushes a Github Pre-release based on the tag name.
* Live release- When we squash and merge from development we ingest a `version.txt` file in the repo to generate a subfolder for that release and push the latest stuff to the root of the domain. This also pushes a github release based on the version name 

Tag names used for RCs should be like `1.05-RC` while the version.txt would contain `1.05`
For both RC and Live builds we actually build twice to have locked in boot medium to the specific version folder and then the latest style stuff pointed to the rc and / folders.

Let me know if you have any questions. I looped what I could on my fork including S3 uploads, but with travis a lot of this stuff needs to be done live. 