### PR TITLE
adding zorin backbox peppermint Q4OS voyager to the live menus

### DIFF
--- a/roles/netbootxyz/templates/menu/live-backbox.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-backbox.ipxe.j2
@@ -1,0 +1,37 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os BackBox
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+item 6 ${space} ${os} 6
+choose live_version || goto live_exit
+goto ${live_version}
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "BackBox" and 'squash' in key %}
+{% set kernel_name = value.kernel %}
+:{{ value.version }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+{% for key, value in endpoints.items() | sort %}
+{% if key == kernel_name %}
+set kernel_url ${live_endpoint}{{ value.path }}
+{% endif %}
+{% endfor %}
+goto {{ value.version }}-boot
+{% endif %}
+{% endfor %}
+
+:6-boot
+imgfree
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0
+

--- a/roles/netbootxyz/templates/menu/live-peppermint.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-peppermint.ipxe.j2
@@ -1,0 +1,37 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Peppermint
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+item 10 ${space} ${os} 10
+choose live_version || goto live_exit
+goto ${live_version}
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "peppermint" and 'squash' in key %}
+{% set kernel_name = value.kernel %}
+:{{ value.version }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+{% for key, value in endpoints.items() | sort %}
+{% if key == kernel_name %}
+set kernel_url ${live_endpoint}{{ value.path }}
+{% endif %}
+{% endfor %}
+goto {{ value.version }}-boot
+{% endif %}
+{% endfor %}
+
+:10-boot
+imgfree
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0
+

--- a/roles/netbootxyz/templates/menu/live-q4os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-q4os.ipxe.j2
@@ -1,0 +1,37 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Q4OS
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+item 3.9 ${space} ${os} 3.9
+choose live_version || goto live_exit
+goto ${live_version}
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "q4os" and 'squash' in key %}
+{% set kernel_name = value.kernel %}
+:{{ value.version }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+{% for key, value in endpoints.items() | sort %}
+{% if key == kernel_name %}
+set kernel_url ${live_endpoint}{{ value.path }}
+{% endif %}
+{% endfor %}
+goto {{ value.version }}-boot
+{% endif %}
+{% endfor %}
+
+:3.9-boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0
+

--- a/roles/netbootxyz/templates/menu/live-voyager.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-voyager.ipxe.j2
@@ -1,0 +1,41 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Voyager Live
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+item bionic ${space} ${os} Bionic
+item buster ${space} ${os} Buster
+item eoan ${space} ${os} Eoan
+choose live_version || goto live_exit
+
+:bionic
+set squash_url ${live_endpoint}{{ endpoints["voyager-bionic-squash"].path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ endpoints["ubuntu-18.04-live-kernel"].path }}
+imgfree
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:buster
+set squash_url ${live_endpoint}{{ endpoints["voyager-buster-squash"].path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ endpoints["debian-10-live-kernel"].path }}
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:eoan
+set squash_url ${live_endpoint}{{ endpoints["voyager-eoan-squash"].path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ endpoints["ubuntu-19.10-live-kernel"].path }}
+imgfree
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/live-zorin.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-zorin.ipxe.j2
@@ -1,0 +1,52 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Zorin Live
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+item 15 ${space} ${os} 15
+choose live_version || goto live_exit
+menu ${os} ${live_version}
+item --gap ${os} Flavors
+goto ${live_version}
+
+:15
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "zorin" and 'squash' in key and value.version == "15" %}
+item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
+{% endif %}
+{% endfor %}
+goto flavor_select
+
+:flavor_select
+choose flavor || goto live_menu
+echo ${cls}
+goto ${flavor} ||
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "zorin" and 'squash' in key %}
+{% set kernel_name = value.kernel %}
+:{{ key }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+{% for key, value in endpoints.items() | sort %}
+{% if key == kernel_name %}
+set kernel_url ${live_endpoint}{{ value.path }}
+{% endif %}
+{% endfor %}
+goto {{ value.version }}-boot
+{% endif %}
+{% endfor %}
+
+:15-boot
+imgfree
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0
+

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -6,16 +6,21 @@ goto ${menu} ||
 menu Live Boot Distributions - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 item --gap Live Boot Distributions
+item live-backbox ${space} BackBox
 item live-debian ${space} Debian
 item live-elementary ${space} elementary OS
 item live-fedora ${space} Fedora
 item live-kali ${space} Kali
+item live-q4os ${space} Q4OS
 item live-manjaro ${space} Manjaro
 item live-mint ${space} Mint
+item live-peppermint ${space} Peppermint
 item live-popos ${space} Pop OS
 item live-slitaz ${space} Slitaz
 item live-tails ${space} Tails
 item live-ubuntu ${space} Ubuntu
+item live-voyager ${space} Voyager
+item live-zorin ${space} Zorin OS
 choose menu || goto live_exit
 echo ${cls}
 goto ${menu} ||


### PR DESCRIPTION
This should be it for low hanging fruit that can directly use our boot kernels without modification. 
My cutoff was top 100 on distrowatch. 