### PR TITLE
Add versioning, only update boot files for rolling

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -3,7 +3,7 @@
 ### site configuration ###
 site_name: netboot.xyz
 boot_domain: boot.netboot.xyz
-boot_version: 1.04
+boot_version: "2.x"
 boot_timeout: 300000
 time_server: "0.pool.ntp.org"
 

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -8,8 +8,9 @@ set cls:hex 1b:5b:4a  # ANSI clear screen sequence - "^[[J"
 set cls ${cls:string}
 :ignore_cls
 
+{% if 'x' in boot_version %}
 :version_check
-set latest_version 1.04
+set latest_version {{ boot_version }}
 echo ${cls}
 iseq ${version} ${latest_version} && goto version_up2date ||
 echo
@@ -23,6 +24,7 @@ echo
 echo Attempting to chain to latest version...
 chain --autofree http://${boot_domain}/ipxe/${ipxe_disk} ||
 :version_up2date
+{% endif %}
 
 isset ${arch} && goto skip_arch_detect ||
 cpuid --ext 29 && set arch x86_64 || set arch i386

--- a/script/build_release
+++ b/script/build_release
@@ -1,19 +1,28 @@
 #!/bin/bash
-
 set -e
 
 TYPE=$1
+HARD_RELEASE="2.x"
+HARD_RC="2.x-RC"
+LIVE_URL="staging.boot.netboot.xyz"
 
 # Set boot domain
 if [[ "${TYPE}" == "dev" ]]; then
   BOOT_DOMAIN="s3.amazonaws.com/${BUCKET_DEV}/${TRAVIS_COMMIT}"
+  BOOT_VERSION="Development"
 elif [[ "${TYPE}" == "pr" ]]; then
   BOOT_DOMAIN="test.com"
+  BOOT_VERSION="test"
 elif [[ "${TYPE}" == "rc" ]]; then
-  BOOT_DOMAIN="staging.boot.netboot.xyz/$(cat version.txt)-RC"
+  BOOT_VERSION=$(cat version.txt)-RC
+  BOOT_DOMAIN="${LIVE_URL}/${BOOT_VERSION}"
 elif [[ "${TYPE}" == "release" ]]; then
-  BOOT_DOMAIN="staging.boot.netboot.xyz/$(cat version.txt)"
+  BOOT_VERSION=$(cat version.txt)
+  BOOT_DOMAIN="${LIVE_URL}/${BOOT_VERSION}"
 fi
+sed -i \
+  "/^#boot_version/c\boot_version: \"${BOOT_VERSION}\"" \
+  user_overrides.yml
 sed -i \
   "/^#boot_domain/c\boot_domain: ${BOOT_DOMAIN}" \
   user_overrides.yml
@@ -39,14 +48,16 @@ if [[ "${TYPE}" == "release" ]] || [[ "${TYPE}" == "rc" ]]; then
   rm -Rf buildout/
   if [[ "${TYPE}" == "release" ]]; then
     sed -i \
-      "/^boot_domain/c\boot_domain: staging.boot.netboot.xyz" \
+      -e "/^boot_version/c\boot_version: \"${HARD_RELEASE}\"" \
+      -e "/^boot_domain/c\boot_domain: ${LIVE_URL}" \
       user_overrides.yml
     docker build -t localbuild -f Dockerfile-build .
     docker run --rm -it -v $(pwd):/buildout localbuild
   fi
   if [[ "${TYPE}" == "rc" ]]; then
     sed -i \
-      "/^boot_domain/c\boot_domain: staging.boot.netboot.xyz/rc" \
+      -e "/^boot_version/c\boot_version: \"${HARD_RC}\"" \
+      -e "/^boot_domain/c\boot_domain: ${LIVE_URL}/rc" \
       user_overrides.yml
     docker build -t localbuild -f Dockerfile-build .
     docker run --rm -it -v $(pwd):/buildout localbuild

--- a/user_overrides.yml
+++ b/user_overrides.yml
@@ -12,7 +12,7 @@ generate_checksums: true
 #boot_domain: boot.mysitename.com
 
 # set boot version
-#boot_version: 1.00
+#boot_version: "2.x"
 
 #bootloader_tftp_enabled: false
 #bootloader_https_enabled: true


### PR DESCRIPTION
So the basics of this is if the user is using a specific versioned boot medium ( self hosted users and people specifically looking for versioned endpoint ) we do not include the upgrade logic it is redundant as they are already pointed to a static endpoint but there is also no need for it. They will see this specific version in their menu when booting.

If the user downloads the standard rolling release looking at the latest endpoints they will be pinged for an upgrade if we do a major version change ( 2.x to 3.x ) signifying we have made a significant change to the boot medium files and need it's functionality for the new menu files. 

Let me know if you have any questions. 