### PR TITLE
Add EFI detection for out of date loaders and...

### DIFF
--- a/roles/netbootxyz/templates/index.html.j2
+++ b/roles/netbootxyz/templates/index.html.j2
@@ -1,3 +1,15 @@
+#!ipxe
+####       {{ boot_domain }} initial loader        ####
+#### see https://netboot.xyz for more information ####
+{% if bootloader_https_enabled | bool %}
+set conn_type https
+chain --autofree https://{{ boot_domain }}/menu.ipxe || echo HTTPS failed... attempting HTTP...
+{% endif %}
+{% if bootloader_http_enabled | bool %}
+set conn_type http
+chain --autofree http://{{ boot_domain }}/menu.ipxe || echo HTTP failed, localbooting...
+{% endif %}
+
 <!DOCTYPE html>
 <html lang="en">
   <head>

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -10,6 +10,9 @@ set boot_domain {{ boot_domain }}
 # set location of memdisk
 set memdisk {{ memdisk_location }}
 
+# set location of custom netboot.xyz live assets
+set live_endpoint {{ live_endpoint }}
+
 # signature check enabled?
 set sigs_enabled {{ sigs_enabled | default(false) | bool }}
 
@@ -20,10 +23,7 @@ set img_sigs_enabled {{ img_sigs_enabled | default(false) | bool }}
 set sigs {{ sigs_location }}
 
 # set location of latest iPXE
-set ipxe_disk netboot.xyz-undionly.kpxe
-
-# set location of custom netboot.xyz live assets
-set live_endpoint {{ live_endpoint }}
+iseq ${platform} efi && set ipxe_disk netboot.xyz-snponly.efi || set ipxe_disk netboot.xyz-undionly.kpxe
 
 ##################
 # official mirrors


### PR DESCRIPTION
Adds initial loader to index.html, this will appear
as a small blurb at the top of the main index for the
disks on the boot.netboot.xyz top level domain for now.

Shifts live_endpoint up in config