### PR TITLE
Enable console option in iPXE bootloaders

### DIFF
--- a/roles/netbootxyz/files/ipxe/local/console.h
+++ b/roles/netbootxyz/files/ipxe/local/console.h
@@ -1,0 +1,1 @@
+#define	CONSOLE_FRAMEBUFFER	/* Graphical framebuffer console */

--- a/roles/netbootxyz/files/ipxe/local/general.h
+++ b/roles/netbootxyz/files/ipxe/local/general.h
@@ -1,3 +1,4 @@
+#define CONSOLE_CMD		      /* Console command */
 #define DIGEST_CMD            /* Image crypto digest commands */
 #define DOWNLOAD_PROTO_HTTPS  /* Secure Hypertext Transfer Protocol */      
 #define IMAGE_COMBOOT         /* COMBOOT */

--- a/roles/netbootxyz/files/ipxe/local/general.h.efi
+++ b/roles/netbootxyz/files/ipxe/local/general.h.efi
@@ -1,3 +1,4 @@
+#define CONSOLE_CMD		      /* Console command */
 #define DIGEST_CMD            /* Image crypto digest commands */
 #define DOWNLOAD_PROTO_HTTPS  /* Secure Hypertext Transfer Protocol */      
 #define IMAGE_TRUST_CMD	      /* Image trust management commands */

--- a/roles/netbootxyz/tasks/generate_disks_arm.yml
+++ b/roles/netbootxyz/tasks/generate_disks_arm.yml
@@ -6,6 +6,7 @@
         dest: "{{ ipxe_source_dir }}/src/config/local/{{ item }}"
       with_items:
         - colour.h
+        - console.h
         - crypto.h
 
     - name: Copy netboot.xyz general.h.efi iPXE config

--- a/roles/netbootxyz/tasks/generate_disks_base.yml
+++ b/roles/netbootxyz/tasks/generate_disks_base.yml
@@ -56,7 +56,6 @@
       path: "{{ ipxe_source_dir }}/{{ item }}"
       state: touch
     with_items:
-      - src/config/local/console.h
       - src/config/local/umalloc.h
       - src/config/local/nap.h
       - src/config/local/timer.h

--- a/roles/netbootxyz/tasks/generate_disks_efi.yml
+++ b/roles/netbootxyz/tasks/generate_disks_efi.yml
@@ -6,6 +6,7 @@
       dest: "{{ ipxe_source_dir }}/src/config/local/{{ item }}"
     with_items:
       - colour.h
+      - console.h
       - crypto.h
 
   - name: Copy netboot.xyz general.h.efi iPXE config

--- a/roles/netbootxyz/tasks/generate_disks_legacy.yml
+++ b/roles/netbootxyz/tasks/generate_disks_legacy.yml
@@ -6,6 +6,7 @@
       dest: "{{ ipxe_source_dir }}/src/config/local/{{ item }}"
     with_items:
       - colour.h
+      - console.h
       - crypto.h
       - general.h
 


### PR DESCRIPTION
Enables console option in iPXE bootloaders for future customizations.