### PR TITLE
Exit ipxe script in index, move version check

### DIFF
--- a/roles/netbootxyz/templates/index.html.j2
+++ b/roles/netbootxyz/templates/index.html.j2
@@ -9,6 +9,7 @@ chain --autofree https://{{ boot_domain }}/menu.ipxe || echo HTTPS failed... att
 set conn_type http
 chain --autofree http://{{ boot_domain }}/menu.ipxe || echo HTTP failed, localbooting...
 {% endif %}
+exit
 
 <!DOCTYPE html>
 <html lang="en">

--- a/roles/netbootxyz/templates/menu/about.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/about.ipxe.j2
@@ -16,8 +16,6 @@ set fg_cya ${esc:string}[36m
 set fg_whi ${esc:string}[37m
 
 :netabout
-echo Attempting to retrieve latest upstream version...
-chain https://boot.netboot.xyz/version.ipxe ||
 menu ${fg_cya}${bold}About netboot.xyz (Version: {{ boot_version }})
 item exit ${bold}Exit back to main menu...${boldoff}
 item --gap --  --------------------------------------------------------------------------

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -2,6 +2,8 @@
 
 :start
 chain --autofree boot.cfg ||
+echo Attempting to retrieve latest upstream version number...
+chain https://boot.netboot.xyz/version.ipxe ||
 ntp {{ time_server }} ||
 iseq ${cls} serial && goto ignore_cls ||
 set cls:hex 1b:5b:4a  # ANSI clear screen sequence - "^[[J"


### PR DESCRIPTION
Without exit on index, ipxe script continues to run and fails on html code.  Exit properly so that local boot loads correctly.

Moves upstream version check to menu so that it's always available when menu is loaded.