### PR TITLE
Flush toilet on CentOS since it doesn't exist

### DIFF
--- a/roles/netbootxyz/tasks/generate_checksums.yml
+++ b/roles/netbootxyz/tasks/generate_checksums.yml
@@ -31,6 +31,7 @@
     register: index_title
     tags:
       - skip_ansible_lint
+    when: ansible_os_family == "Debian"
 
   - name: Generate netboot.xyz index template
     template:

--- a/roles/netbootxyz/tasks/generate_disks_base.yml
+++ b/roles/netbootxyz/tasks/generate_disks_base.yml
@@ -12,6 +12,12 @@
       - "{{ ansible_distribution | lower }}.yml"
       - "{{ ansible_os_family | lower }}.yml"
 
+  - name: Ensure EPEL is enabled
+    yum:
+      name: epel-release
+      state: present
+    when: ansible_os_family == "RedHat"
+
   - name: Set var to bootloader of loop
     set_fact:
       bootloader_filename: "{{ bootloader_file }}"

--- a/roles/netbootxyz/templates/index.html.j2
+++ b/roles/netbootxyz/templates/index.html.j2
@@ -24,7 +24,11 @@ exit
   </style>
   <body>
   <div style="font-family: monospace, fixed; font-weight: bold;">
+  {% if index_title is defined %}
   {{ index_title.stdout }}
+  {% else %}
+  <h1>{{ site_name }}</h1>
+  {% endif %}
   <p>
   Version: {{ boot_version }}<br>
   Powered by <a href=https://netboot.xyz>netboot.xyz</a>

--- a/roles/netbootxyz/vars/redhat.yml
+++ b/roles/netbootxyz/vars/redhat.yml
@@ -8,5 +8,4 @@ netbootxyz_packages:
   - httpd
   - minizip-devel
   - syslinux
-  - toilet
   - xz-devel


### PR DESCRIPTION
Removes toilet from CentOS builds as the package isn't present
and just puts a basic banner for the index.