### PR TITLE
need ubiquity kernel command line for installer to start properly

### DIFF
--- a/roles/netbootxyz/templates/menu/live-elementary.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-elementary.ipxe.j2
@@ -27,7 +27,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper maybe-ubiquity netboot=http fetch=${squash_url} initrd=initrd
 initrd ${kernel_url}initrd
 boot
 


### PR DESCRIPTION
Missing kernel params causes livecd to start improperly