### PR TITLE
Windows Testing Fixes

### DIFF
--- a/roles/netbootxyz/templates/menu/windows.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/windows.ipxe.j2
@@ -30,6 +30,7 @@ echo -n URL: ${} && read win_base_url
 echo
 echo netboot.xyz will attempt to load the following files:
 echo ${win_base_url}/${win_arch}/bootmgr
+echo ${win_base_url}/${win_arch}/bootmgr.efi
 echo ${win_base_url}/${win_arch}/boot/bcd
 echo ${win_base_url}/${win_arch}/boot/boot.sdi
 echo ${win_base_url}/${win_arch}/sources/boot.wim
@@ -41,18 +42,13 @@ goto windows
 isset ${win_base_url} && goto boot || echo URL not set... && goto url_set
 
 :boot
+imgfree
 kernel {{ wimboot_location }}
-initrd ${win_base_url}/${win_arch}/bootmgr bootmgr
-initrd ${win_base_url}/${win_arch}/boot/bcd bcd
-initrd ${win_base_url}/${win_arch}/boot/boot.sdi boot.sdi
-initrd ${win_base_url}/${win_arch}/sources/boot.wim boot.wim
-md5sum wimboot
-iseq ${img_sigs_enabled} true && goto verify_sigs || goto skip_sigs
-:verify_sigs
-echo
-echo Checking wimboot signature...
-imgverify wimboot ${sigs}wimboot.sig || goto error
-:skip_sigs
+initrd -n bootmgr     ${win_base_url}/${win_arch}/bootmgr       bootmgr ||
+initrd -n bootmgr.efi ${win_base_url}/${win_arch}/bootmgr.efi   bootmgr.efi ||      
+initrd -n bcd         ${win_base_url}/${win_arch}/boot/bcd      bcd
+initrd -n boot.sdi    ${win_base_url}/${win_arch}/boot/boot.sdi boot.sdi   
+initrd -n boot.wim    ${win_base_url}/${win_arch}/boot/boot.wim boot.wim
 boot
 
 :windows_exit


### PR DESCRIPTION
I wanted to automate Windows download and file org stuff in the web app , went pretty far down the rabbit hole. 
First off good information here: 
http://mistyrebootfiles.altervista.org/documents/TinyPXEServer/files/winpe_wimboot.htm

Without imgfree and the sig check stuff removed I always got `bad cpio magic` from wimboot when trying to extract the files. 

I got this booting in VM and bare metal, Bare metal gets farther in the install process though it asks for a USB/CD containing drivers to load up stuff. 
To do win7 all the files would need to be renamed, though given it is EOL I think we should be good with win10 support only. 