### PR TITLE
Add timeout to version check

### DIFF
--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -3,7 +3,7 @@
 :start
 chain --autofree boot.cfg ||
 echo Attempting to retrieve latest upstream version number...
-chain https://boot.netboot.xyz/version.ipxe ||
+chain --timeout 5 https://boot.netboot.xyz/version.ipxe ||
 ntp {{ time_server }} ||
 iseq ${cls} serial && goto ignore_cls ||
 set cls:hex 1b:5b:4a  # ANSI clear screen sequence - "^[[J"


### PR DESCRIPTION
As version check is not critical and more informational,
ensure it doesn't hang startup for a long period of time.
If unreachable, it will timeout and continue with boot.