### PR TITLE
need to remove live-cd installer to boot into live mode

### DIFF
--- a/roles/netbootxyz/templates/menu/live-deepin.ipxe
+++ b/roles/netbootxyz/templates/menu/live-deepin.ipxe
@@ -18,7 +18,7 @@ goto live-boot
 
 :15-boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} union=overlay livecd-installer initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} union=overlay initrd=initrd
 initrd ${kernel_url}initrd
 boot
 


### PR DESCRIPTION
I had all this stuff local including the Deepin changes I just forgot to push them. 

If we want this in 2.0.2 we can just ignore a successul RC build. 