### PR TITLE
Correct timeout for 5 sec in milliseconds

### DIFF
--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -3,7 +3,7 @@
 :start
 chain --autofree boot.cfg ||
 echo Attempting to retrieve latest upstream version number...
-chain --timeout 5 https://boot.netboot.xyz/version.ipxe ||
+chain --timeout 5000 https://boot.netboot.xyz/version.ipxe ||
 ntp {{ time_server }} ||
 iseq ${cls} serial && goto ignore_cls ||
 set cls:hex 1b:5b:4a  # ANSI clear screen sequence - "^[[J"


### PR DESCRIPTION
Timeout was set to 5 milliseconds instead of secs.