### PR TITLE
Flip certain menus off when in EFI mode

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -215,7 +215,7 @@ releases:
     mirror: "http://http.kali.org"
     base_dir: "kali"
     enabled: true
-    menu: "security"
+    menu: "linux"
     versions:
       - name: "Rolling Edition (2019.4)"
         code_name: "rolling"

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -60,6 +60,7 @@ iseq ${buildarch} x86_64 && goto x86_64 ||
 iseq ${buildarch} arm64 && goto arm64 ||
 goto architectures_end
 :x86_64
+iseq ${platform} efi && goto efi ||
 goto architectures_end
 :arm64
 set menu_freedos 0
@@ -67,6 +68,12 @@ set menu_live 0
 set menu_security 0
 set menu_windows 0
 set menu_utils 0
+iseq ${platform} efi && goto efi ||
+goto architectures_end
+:efi
+set menu_bsd 0
+set menu_freedos 0
+set menu_security 0
 goto architectures_end
 :architectures_end
 goto clouds


### PR DESCRIPTION
Disables menus that utilize memdisk to boot when using
EFI mode.  Moves Kali Linux to from Security to Linux menu
as it has a normal kernel level install and the other
security distros all use memdisk.