### PR TITLE
Exit version properly once chain has completed

### DIFF
--- a/roles/netbootxyz/templates/version.ipxe.j2
+++ b/roles/netbootxyz/templates/version.ipxe.j2
@@ -2,3 +2,4 @@
 {% if upstream_version %}
 set upstream_version {{ upstream_version }}
 {% endif %}
+exit


### PR DESCRIPTION
Adds an exit so that the version.ipxe is exited properly.