### PR TITLE
Save the ipxe_version compiled version

### DIFF
--- a/roles/netbootxyz/templates/disks/netboot.xyz-gce.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz-gce.j2
@@ -7,7 +7,8 @@ set fg_cya ${esc:string}[36m
 set fg_whi ${esc:string}[37m
 set HTTPS_ERR HTTPS appears to have failed... attempting HTTP
 set HTTP_ERR HTTP has failed, localbooting...
-set version 1.04
+set ipxe_version ${version}
+set version {{ boot_version }}
 set ipxe_cloud_config gce
 
 :start

--- a/roles/netbootxyz/templates/disks/netboot.xyz-packet.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz-packet.j2
@@ -8,7 +8,8 @@ set fg_cya ${esc:string}[36m
 set fg_whi ${esc:string}[37m
 set HTTPS_ERR HTTPS appears to have failed... attempting HTTP
 set HTTP_ERR HTTP has failed, localbooting...
-set version 1.04
+set ipxe_version ${version}
+set version {{ boot_version }}
 set ipxe_cloud_config packet
 
 :start

--- a/roles/netbootxyz/templates/disks/netboot.xyz.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz.j2
@@ -10,6 +10,7 @@ set HTTPS_ERR HTTPS appears to have failed... attempting HTTP
 set HTTP_ERR HTTP has failed, localbooting...
 set site_name {{ site_name }}
 set boot_domain {{ boot_domain }}
+set ipxe_version ${version}
 set version {{ boot_version }}
 
 :start


### PR DESCRIPTION
Saves the original version variable that contains the ipxe version
as ipxe_version so that it can be referenced as needed.

Also ensures the other ipxe disks are using the correct boot_version
variable.