### PR TITLE
adding ferenOS to live menu

### DIFF
--- a/roles/netbootxyz/templates/menu/live-feren.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-feren.ipxe.j2
@@ -1,0 +1,36 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Feren OS Live
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+item current ${space} ${os} Current
+choose live_version || goto live_exit
+menu ${os} ${live_version}
+item --gap ${os} Flavors
+goto ${live_version}
+
+:current
+{% for key, value in endpoints.items() %}
+{% if value.os == "feren" %}
+item {{ value.path }} ${space} {{ value.os | title }} {{ value.version | title }}
+{% endif %}
+{% endfor %}
+choose path || goto live_menu
+goto feren-boot
+
+:feren-boot
+imgfree
+set squash_url ${live_endpoint}${path}filesystem.squashfs
+set kernel_url ${live_endpoint}${path}
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0
+

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -11,6 +11,7 @@ item live-debian ${space} Debian
 item live-deepin ${space} Deepin
 item live-elementary ${space} elementary OS
 item live-fedora ${space} Fedora
+item live-feren ${space} Feren OS
 item live-kali ${space} Kali
 item live-neon ${space} KDE Neon
 item live-lite ${space} Linux Lite


### PR DESCRIPTION
Standard does not play nice with Virtualbox but is good on bare metal. 

Standard live boot add here, manual babysit version until they have some kind of mirror off sourceforge with versioning setup. 