### PR TITLE
Clonezilla live assets, support live assets in utility menu

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -364,63 +364,60 @@ releases:
         code_name: "xenial"
 
 # utility values
-utilities:
+utilitiespcbios:
   avg:
     name: "AVG Rescue CD"
     enabled: true
-    menu: "pcbios"
     type: "memdisk"
     version: "160420a12074"
     util_path: "http://download.avg.com/filedir/inst/avg_arl_cdi_all_120_160420a12074.iso"
   breakin:
     name: "Breakin"
     enabled: true
-    menu: "pcbios"
     type: "memdisk"
     version: "4.26.1-53"
     util_path: "http://www.advancedclustering.com/wp-content/uploads/2017/02/bootimage-4.26.1-53.iso"
   clonezilla:
     name: "Clonezilla"
     enabled: true
-    menu: "pcbios"
-    type: "memdisk"
-    version: "2.6.4-10"
-    util_path: "http://master.dl.sourceforge.net/project/clonezilla/clonezilla_live_stable/2.6.4-10/clonezilla-live-2.6.4-10-amd64.iso"
+    type: "live"
   dban:
     name: "DBAN"
     enabled: true
-    menu: "pcbios"
     type: "memdisk"
     version: "2.3.0"
     util_path: "http://master.dl.sourceforge.net/project/dban/dban/dban-2.3.0/dban-2.3.0_i586.iso"
   gparted:
     name: "GParted"
     enabled: true
-    menu: "pcbios"
     type: "memdisk"
     version: "1.0.0-3"
     util_path: "http://master.dl.sourceforge.net/project/gparted/gparted-live-stable/1.0.0-3/gparted-live-1.0.0-3-amd64.iso"
   memtest:
     name: "Memtest"
     enabled: true
-    menu: "pcbios"
     type: "memtest"
     version: "5.01.0"
     util_path: "https://boot.netboot.xyz/utils/memtest86-5.01.0"
   supergrub:
     name: "SuperGRUB"
     enabled: true
-    menu: "pcbios"
     type: "memdisk"
     version: "2.04s1"
     util_path: "http://master.dl.sourceforge.net/project/supergrub2/2.04s1/super_grub2_disk_2.04s1/super_grub2_disk_hybrid_2.04s1.iso"
   ubcd:
     name: "Ultimate Boot CD (UBCD)"
     enabled: true
-    menu: "pcbios"
     type: "memdisk"
     version: "538"
     util_path: "http://mirror.sysadminguide.net/ubcd/ubcd538.iso"
+
+# efi utility values
+utilitiesefi:
+  clonezilla:
+    name: "Clonezilla"
+    enabled: true
+    type: "live"
 
 bootloaders:
   legacy:

--- a/roles/netbootxyz/templates/menu/clonezilla.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/clonezilla.ipxe.j2
@@ -1,0 +1,45 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Clonezilla
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+item debian ${space} ${os} Debian Based
+item ubuntu ${space} ${os} Ubuntu Based
+choose live_version || goto live_exit
+menu ${os} ${live_version}
+item --gap ${os} Flavors
+goto ${live_version}
+
+:debian
+{% for key, value in endpoints.items() %}
+{% if value.os == "clonezilla" and value.version == "debian" %}
+item {{ value.path }} ${space} {{ value.os | title }} {{ value.version | title }} {{ value.flavor | title }}
+{% endif %}
+{% endfor %}
+choose path || goto live_menu
+goto clonezilla-boot
+
+:ubuntu
+{% for key, value in endpoints.items() %}
+{% if value.os == "clonezilla" and value.version == "ubuntu" %}
+item {{ value.path }} ${space} {{ value.os | title }} {{ value.version | title }} {{ value.flavor | title }}
+{% endif %}
+{% endfor %}
+choose path || goto live_menu
+goto clonezilla-boot
+
+:clonezilla-boot
+imgfree
+set url ${live_endpoint}${path}
+kernel ${url}vmlinuz boot=live username=user union=overlay config components noswap edd=on nomodeset ocs_live_run="ocs-live-general" ocs_live_batch=no net.ifnames=0 nosplash noprompt fetch=${url}filesystem.squashfs initrd=initrd
+initrd ${url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0
+

--- a/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
@@ -2,8 +2,8 @@
 
 menu Utilities - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Utilities:
-{% for key, value in utilities.items() | sort(attribute='1.name') %}
-{% if value.enabled | bool and value.menu == "efi" %}
+{% for key, value in utilitiesefi.items() | sort(attribute='1.name') %}
+{% if value.enabled %}
 item {{ key }} ${space} {{ value.name }}
 {% endif %}
 {% endfor %}
@@ -17,8 +17,8 @@ goto ${menu} ||
 chain ${menu}.ipxe || goto utils_exit
 goto utils_exit
 
-{% for key, value in utilities.items() | sort %}
-{% if value.enabled | bool and value.menu == "efi" %}
+{% for key, value in utilitiesefi.items() | sort %}
+{% if value.enabled | bool and value.type == "memdisk" %}
 :{{ key }}
 set util_path {{ value.util_path }}
 set util_file {{ value.util_path | basename }}

--- a/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
@@ -2,8 +2,8 @@
 
 menu Utilities - Image Sig Checks: [${img_sigs_enabled}]
 item --gap Utilities:
-{% for key, value in utilities.items() | sort(attribute='1.name') %}
-{% if value.enabled | bool and value.menu == "pcbios" %}
+{% for key, value in utilitiespcbios.items() | sort(attribute='1.name') %}
+{% if value.enabled %}
 item {{ key }} ${space} {{ value.name }}
 {% endif %}
 {% endfor %}
@@ -17,8 +17,8 @@ goto ${menu} ||
 chain ${menu}.ipxe || goto utils_exit
 goto utils_exit
 
-{% for key, value in utilities.items() | sort %}
-{% if value.enabled | bool and value.menu == "pcbios" %}
+{% for key, value in utilitiespcbios.items() | sort %}
+{% if value.enabled | bool and value.type == "memdisk" %}
 :{{ key }}
 set util_path {{ value.util_path }}
 set util_file {{ value.util_path | basename }}


### PR DESCRIPTION
In order to use identical key names for menu entries we need a separate yaml array for UEFI stuff. 

This does not offer any scripted customization from the ipxe menu though it should be OK for an initial release it is certainly better than memdisk. 
Also on boot Clonezilla lets you set remote scripted install locations so not sure what benefit there is to doing it in IPXE. If a user want to use hooks they should be local hosting and customizing the clonezilla.ipxe file. 