### PR TITLE
Small fixes for 2.0.4 release

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -413,7 +413,7 @@ utilitiespcbios:
 utilitiesefi:
   breakin:
     name: "Breakin"
-    enabled: true
+    enabled: false
     type: "direct"
     kernel: "${live_endpoint}{{ endpoints.breakin.path }}vmlinuz sshpasswd=breakin startup=breakin initrd=initrd"
     initrd: "${live_endpoint}{{ endpoints.breakin.path }}initrd"
@@ -423,7 +423,7 @@ utilitiesefi:
     type: "ipxemenu"
   dban:
     name: "DBAN"
-    enabled: true
+    enabled: false
     type: "ipxemenu"
 
 bootloaders:

--- a/roles/netbootxyz/templates/menu/lspci.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/lspci.ipxe.j2
@@ -3,7 +3,8 @@
 # gather pci devices and list them
 clear addr
 pciscan addr && goto pciscan_found ||
-echo No pci devices found...
+echo No PCI devices found...
+sleep 5
 exit
 :pciscan_found
 

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -118,8 +118,7 @@ iseq ${img_sigs_enabled} true && set img_sigs_enabled false || set img_sigs_enab
 goto main_menu
 
 :about
-chain https://boot.netboot.xyz/about.ipxe ||
-chain about.ipxe || goto error
+chain https://boot.netboot.xyz/about.ipxe || chain about.ipxe 
 goto main_menu
 
 :custom-github


### PR DESCRIPTION
Disable Breakin and DBAN on UEFI as kernels are too old
Prevent double-loading of about
Add a sleep when no PCI devices found for user to see error