### PR TITLE
Adds netboot.xyz endpoints menu for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,15 @@ jobs:
           skip_cleanup: true
           on:
             branch: development
+        - provider: s3
+          edge: true
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $BUCKET_DEV
+          local_dir: s3outver
+          skip_cleanup: true
+          on:
+            branch: development
       after_deploy:
         - ./script/message dev-push
 
@@ -77,6 +86,15 @@ jobs:
           bucket: $BUCKET_STAGING
           local_dir: s3out
           upload-dir: $RELEASE_TAG
+          skip_cleanup: true
+          on:
+            branch: RC
+        - provider: s3
+          edge: true
+          access_key_id: $AWS_ACCESS_KEY_ID
+          secret_access_key: $AWS_SECRET_ACCESS_KEY
+          bucket: $BUCKET_STAGING
+          local_dir: s3outver
           skip_cleanup: true
           on:
             branch: RC

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -29,7 +29,7 @@ live_endpoint: "https://github.com/netbootxyz"
 
 # generates menus
 generate_menus: true
-generate_version_file: false
+generate_version_file: true
 
 # generates signatures for source files
 generate_checksums: true

--- a/roles/netbootxyz/tasks/generate_menus.yml
+++ b/roles/netbootxyz/tasks/generate_menus.yml
@@ -24,17 +24,9 @@
       path: "{{ netbootxyz_root }}"
       state: directory
 
-  - name: Get current menu version
-    shell: cat version.txt
-    register: menu_version
-    when:
-      - generate_version_file | bool
-    tags:
-      - skip_ansible_lint
-
   - name: Set menu version
     set_fact:
-      upstream_version: "{{ menu_version.stdout }}"
+      upstream_version: "{{ boot_version }}"
     when:
       - generate_version_file | bool
 

--- a/roles/netbootxyz/templates/menu/nbxyz.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/nbxyz.ipxe.j2
@@ -1,0 +1,41 @@
+#!ipxe
+
+# netboot.xyz endpoints
+# used for accessing the latest internet build menus
+goto ${menu} ||
+
+:nbxyz
+set os netboot.xyz internet endpoints
+clear nbxyz_version
+menu ${os}
+item --gap Endpoints
+item nbxyz-rolling ${space} ${os} Production Rolling (boot.netboot.xyz)
+item nbxyz-prod ${space} ${os} Production Release (boot.netboot.xyz)
+item nbxyz-staging ${space} ${os} Staging (staging.boot.netboot.xyz)
+item nbxyz-dev ${space} ${os} Development (dev.boot.netboot.xyz)
+item --gap Options:
+choose nbxyz_version || goto nbxyz_exit
+goto ${nbxyz_version}
+
+:nbxyz-rolling
+chain --autofree https://boot.netboot.xyz ||
+chain --autofree http://boot.netboot.xyz ||
+goto nbxyz
+
+:nbxyz-prod
+chain https://boot.netboot.xyz/version.ipxe ||
+chain --autofree https://boot.netboot.xyz/${upstream_version} ||
+goto nbxyz
+
+:nbxyz-staging
+chain https://staging.boot.netboot.xyz/version.ipxe ||
+chain --autofree https://staging.boot.netboot.xyz/${upstream_version} ||
+goto nbxyz
+
+:nbxyz-dev
+chain https://s3.amazonaws.com/dev.boot.netboot.xyz/version.ipxe ||
+chain --autofree https://s3.amazonaws.com/dev.boot.netboot.xyz/${upstream_version} ||
+goto nbxyz
+
+:nbxyz_exit
+exit 0

--- a/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
@@ -9,8 +9,8 @@ item {{ key }} ${space} {{ value.name }}
 {% endfor %}
 item --gap netboot.xyz tools:
 item nbxyz-custom ${space} Set Github username [user: ${github_user}]
-item testdistro ${space} Test Distribution ISO
 item testpr ${space} Test forked netboot.xyz branch or hash
+item nbxyz netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
 echo ${cls}
 goto ${menu} ||
@@ -36,16 +36,6 @@ echo You can then customize your fork as needed and set up your own custom optio
 echo Once your username is set, a custom option will appear on the main menu.
 echo
 echo -n Please enter your Github username: ${} && read github_user
-goto utils_exit 
-
-:testdistro
-echo This option will allow you to test booting an ISO using memdisk. Please
-echo specify the URL of the ISO you want to test and it will automatically
-echo attempt to load the ISO using memdisk.
-echo -n URL: ${} && read distro_iso
-kernel ${memdisk} iso raw
-initrd ${distro_iso}
-boot
 goto utils_exit
 
 :testpr

--- a/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
@@ -11,6 +11,7 @@ item --gap netboot.xyz tools:
 item nbxyz-custom ${space} Set Github username [user: ${github_user}]
 item testdistro ${space} Test Distribution ISO
 item testpr ${space} Test forked netboot.xyz branch or hash
+item nbxyz netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
 echo ${cls}
 goto ${menu} ||

--- a/script/build_release
+++ b/script/build_release
@@ -11,8 +11,8 @@ DOCKER_FILE="Dockerfile-build.production"
 
 # Set boot domain
 if [[ "${TYPE}" == "dev" ]]; then
-  BOOT_DOMAIN="s3.amazonaws.com/${DEV_URL}/${TRAVIS_COMMIT}"
-  BOOT_VERSION="Development"
+  BOOT_DOMAIN="s3.amazonaws.com/${DEV_URL}/${BOOT_VERSION}"
+  BOOT_VERSION="${TRAVIS_COMMIT}"
 elif [[ "${TYPE}" == "pr" ]]; then
   BOOT_DOMAIN="test.com"
   BOOT_VERSION="test"
@@ -37,7 +37,9 @@ docker run --rm -it -v $(pwd):/buildout localbuild
 
 # Generate folder outputs
 mkdir -p s3out
+mkdir -p s3outver
 cp -r buildout/* s3out/
+cp buildout/version.ipxe s3outver/
 mkdir -p githubout
 mv buildout/ipxe/* githubout/
 cd buildout


### PR DESCRIPTION
Uploads version.ipxe to root of endpoints so that latest
deployed version can be loaded.

Removes memdisk iso test from efi utils menu.