### PR TITLE
enable auto login for rancher and prune uneeded options

### DIFF
--- a/roles/netbootxyz/templates/menu/rancheros.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rancheros.ipxe.j2
@@ -19,10 +19,8 @@ set folder ${rancheros_base_dir}
 goto boot
 
 :boot
-echo Login in with username: rancher, password: rancher
-echo To install: ros install -d /dev/sda1
 imgfree
-kernel ${url}/${folder}/vmlinuz rancher.state.autoformat=[/dev/sda] rancher.password=rancher initrd=initrd
+kernel ${url}/${folder}/vmlinuz rancher.autologin=tty initrd=initrd
 initrd ${url}/${folder}/initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/rancheros.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rancheros.ipxe.j2
@@ -20,7 +20,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}/${folder}/vmlinuz rancher.autologin=tty initrd=initrd
+kernel ${url}/${folder}/vmlinuz rancher.autologin=tty1 initrd=initrd
 initrd ${url}/${folder}/initrd
 boot
 


### PR DESCRIPTION
They have auto login option now among other new stuff: 

https://github.com/rancher/os/releases/download/v1.5.5/rancheros.ipxe

From a live web bootable standpoint this is the only one we want though. 