### PR TITLE
prune pureos they do not provide libnss in their initrd files

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -785,13 +785,3 @@ endpoints:
     version: rolling
     flavor: lxqt
     kernel: sparky-rolling-lxqt
-  pureos-gnome:
-    path: /ubuntu-squash/releases/download/2020-01-06-269c1164/
-    files:
-    - filesystem.squashfs
-    - initrd
-    - vmlinuz
-    os: pureos
-    version: current
-    flavor: gnome
-    kernel: pureos-gnome


### PR DESCRIPTION
When I tested locally I was using IPs, did not realize their initrd files do not contain libnss, compiling and linking those libs in is too much of a pain to maintain. 

Just pulling from assets. 