### PR TITLE
adding oracle linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 |NixOS|https://nixos.org| Yes | No |
 |OpenBSD|https://openbsd.org| Yes | No |
 |OpenSUSE|https://opensuse.org| Yes | No |
+|Oracle Linux|https://www.oracle.com/linux/| Yes | Installer |
 |Parrot Security|https://www.parrotsec.org| ISO | No |
 |Peppermint|https://peppermintos.com | No | Yes |
 |Pop OS|https://system76.com/pop| No | Yes |

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -298,8 +298,12 @@ releases:
         code_name: "tumbleweed"
   oracle:
     name: "Oracle Linux"
+    mirror: "https://yum.oracle.com"
     enabled: true
     menu: "linux"
+    paths:
+      7: "/repo/OracleLinux/OL7/latest/x86_64"
+      8: "/repo/OracleLinux/OL8/baseos/latest/x86_64" 
   parrotsec:
     name: "Parrot Security"
     mirror: "https://mirrordirector.archive.parrotsec.org"

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -296,6 +296,10 @@ releases:
         code_name: "42.3"
       - name: "openSUSE tumbleweed"
         code_name: "tumbleweed"
+  oracle:
+    name: "Oracle Linux"
+    enabled: true
+    menu: "linux"
   parrotsec:
     name: "Parrot Security"
     mirror: "https://mirrordirector.archive.parrotsec.org"

--- a/roles/netbootxyz/templates/menu/oracle.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/oracle.ipxe.j2
@@ -23,6 +23,7 @@ goto ${version}
 {% if value.os == "oracle" %}
 :{{ value.version }}
 set url ${live_endpoint}{{ value.path }}
+set repo {{ releases.oracle.mirror }}{{ releases.oracle.paths[value.version|int] }}
 goto boot
 
 {% endif %}
@@ -30,7 +31,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz ${ipparam} root=live:${url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd
+kernel ${url}vmlinuz ${ipparam} repo=${repo} root=live:${url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/oracle.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/oracle.ipxe.j2
@@ -1,0 +1,40 @@
+#!ipxe
+
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none nameserver=${dns}
+set ipparam BOOTIF=${netX/mac} ${ipparam}
+
+goto ${menu} ||
+
+:oracle_menu
+set os Oracle Linux
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "oracle" %}
+item {{ value.version }} ${space} ${os} {{ value.version }}
+{% endif %}
+{% endfor %}
+choose version || goto oracle_exit
+goto ${version}
+
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "oracle" %}
+:{{ value.version }}
+set url ${live_endpoint}{{ value.path }}
+goto boot
+
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${url}vmlinuz ${ipparam} root=live:${url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd
+initrd ${url}initrd
+boot
+
+:oracle_exit
+clear menu
+exit 0
+


### PR DESCRIPTION
No repo vars initially though I believe you can still pass them. 
Need to use assets as they only do ISOs publically hosted. 

Tested on VM bios/UEFI and hardware bios/UEFI. 