### PR TITLE
adding bodhi linux to live menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 
 | Name       | URL             | Installer Kernel | Live OS       |
 |------------|-----------------|------------------|---------------|
-|Alpine Linux| https://alpinelinux.org | Yes              | No            |
-|Arch Linux | https://www.archlinux.org| Yes              | No            |
+|Alpine Linux| https://alpinelinux.org | Yes | No |
+|Arch Linux| https://www.archlinux.org| Yes | No |
 |Backbox|https://www.backbox.org | No | Yes |
-|BlackArch Linux|https://blackarch.org| ISO - Memdisk | No                |
+|BlackArch Linux|https://blackarch.org| ISO - Memdisk | No |
+|Bodhi Linux|https://www.bodhilinux.com| No | Yes |
 |CentOS| https://centos.org | Yes | No |
 |Debian| https://debian.org | Yes | Yes|
 |Deepin| https://www.deepin.org | No | Yes |

--- a/roles/netbootxyz/templates/menu/live-bodhi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-bodhi.ipxe.j2
@@ -1,0 +1,37 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Bodhi
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "bodhi" %}
+item {{ value.version }}-{{ value.flavor }} ${space} ${os} {{ value.version }} {{ value.flavor }}
+{% endif %}
+{% endfor %}
+choose live_version || goto live_exit
+goto ${live_version}
+
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "bodhi" %}
+:{{ value.version }}-{{ value.flavor }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ value.path }}
+goto boot
+
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -7,6 +7,7 @@ menu Live Boot Distributions - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 item --gap Live Boot Distributions
 item live-backbox ${space} BackBox
+item live-bodhi ${space} Bodhi
 item live-debian ${space} Debian
 item live-deepin ${space} Deepin
 item live-elementary ${space} elementary OS


### PR DESCRIPTION
Tested on VM and hardware (UEFI/PCBios), depending on Virtualbox version you might get garbled video like deepin.

The standard is pretty minimal and Moksha is unique in Live Distors. 