### PR TITLE
update boot.wim path

### DIFF
--- a/roles/netbootxyz/templates/menu/windows.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/windows.ipxe.j2
@@ -48,7 +48,7 @@ initrd -n bootmgr     ${win_base_url}/${win_arch}/bootmgr       bootmgr ||
 initrd -n bootmgr.efi ${win_base_url}/${win_arch}/bootmgr.efi   bootmgr.efi ||      
 initrd -n bcd         ${win_base_url}/${win_arch}/boot/bcd      bcd
 initrd -n boot.sdi    ${win_base_url}/${win_arch}/boot/boot.sdi boot.sdi   
-initrd -n boot.wim    ${win_base_url}/${win_arch}/boot/boot.wim boot.wim
+initrd -n boot.wim    ${win_base_url}/${win_arch}/sources/boot.wim boot.wim
 boot
 
 :windows_exit


### PR DESCRIPTION
boot.wim is generally located in the sources directory of the image. The "echo" showed the correct path, but the initrd command attempted to load from the wrong path.