### PR TITLE
Additions to support WindowsPE

### DIFF
--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -50,7 +50,7 @@ iseq ${menu_live} 1 && item live ${space} Live CDs ||
 iseq ${menu_bsd} 1 && item bsd ${space} BSD Installs ||
 iseq ${menu_freedos} 1 && item freedos ${space} FreeDOS || 
 iseq ${menu_security} 1 && item security ${space} Security Related ||
-iseq ${menu_windows} 1 && item windows ${space} Windows ||
+iseq ${menu_windows} 1 && item winmenu ${space} Windows Installs ||
 item --gap Tools:
 iseq ${menu_utils} 1 && item utils-${platform} ${space} Utilities ||
 iseq ${arch} x86_64 && set bits 64 || set bits 32

--- a/roles/netbootxyz/templates/menu/winmenu.ipxe
+++ b/roles/netbootxyz/templates/menu/winmenu.ipxe
@@ -1,0 +1,26 @@
+#!ipxe
+
+goto ${menu} ||
+
+:winmenu
+menu Windows Installers - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap Windows Installers:
+item winpe ${space} Windows Preinstallation Environment
+item windows ${space} Windows Images
+choose menu || goto windows_exit
+echo ${cls}
+goto ${menu} ||
+iseq ${sigs_enabled} true && goto verify_sigs || goto change_menu
+
+:verify_sigs
+imgverify ${menu}.ipxe ${sigs}${menu}.ipxe.sig || goto error
+goto change_menu
+
+:change_menu
+chain ${menu}.ipxe || goto error
+goto winmenu
+
+:windows_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/winpe.ipxe
+++ b/roles/netbootxyz/templates/menu/winpe.ipxe
@@ -1,0 +1,55 @@
+#!ipxe
+
+# Microsoft Windows Preinstallation Environment
+# https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/winpe-intro
+
+set win_arch x64
+goto ${menu} ||
+
+:windowspe
+set os Microsoft Windows
+clear win_version
+menu ${os} 
+item --gap Installers
+item win_install ${space} Load ${os} Installer...
+item --gap Options:
+item arch_set ${space} Architecture [ ${win_arch} ]
+item url_set ${space} Base URL [ ${win_base_url} ]
+choose win_version || goto winpe_exit
+goto ${win_version}
+
+:arch_set
+iseq ${win_arch} x64 && set win_arch x86 || set win_arch x64
+goto windowspe
+
+:url_set
+echo Set the HTTP URL of an extracted Windows PE ISO without the trailing slash:
+echo e.g. http://www.mydomain.com/windowspe
+echo
+echo -n URL: ${} && read win_base_url
+echo
+echo netboot.xyz will attempt to load the following files:
+echo ${win_base_url}/${win_arch}/bootmgr
+echo ${win_base_url}/${win_arch}/bootmgr.efi
+echo ${win_base_url}/${win_arch}/Boot/BCD
+echo ${win_base_url}/${win_arch}/Boot/boot.sdi
+echo ${win_base_url}/${win_arch}/sources/boot.wim
+echo
+prompt Press any key to return to Windows Menu...
+goto windowspe
+
+:win_install
+isset ${win_base_url} && goto boot || echo URL not set... && goto url_set
+
+:boot
+imgfree
+kernel http://${boot_domain}/wimboot
+initrd -n bootmgr     ${win_base_url}/${win_arch}/bootmgr       bootmgr ||
+initrd -n bootmgr.efi ${win_base_url}/${win_arch}/bootmgr.efi   bootmgr.efi ||      
+initrd -n bcd         ${win_base_url}/${win_arch}/Boot/BCD      bcd
+initrd -n boot.sdi    ${win_base_url}/${win_arch}/Boot/boot.sdi boot.sdi   
+initrd -n boot.wim    ${win_base_url}/${win_arch}/sources/boot.wim boot.wim
+boot
+
+:winpe_exit
+exit 0


### PR DESCRIPTION
Added a windows menu to select between a Windows Install disc and the Windows Presinstallation Environment. This was necessary due to some case differences between windows images and PE, namely that in the windows image, the boot directory is "boot" and bcd is "bcd" but in PE, boot is "Boot" and bcd is "BCD"  While this doesn't matter in windows, it does in a linux based boot environment and caused a failure. 

I tested this on my personal machine.