### PR TITLE
adding parrot live modify current entry into an installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 |OpenBSD|https://openbsd.org| Yes | No |
 |OpenSUSE|https://opensuse.org| Yes | No |
 |Oracle Linux|https://www.oracle.com/linux/| Yes | Installer |
-|Parrot Security|https://www.parrotsec.org| ISO | No |
+|Parrot Security|https://www.parrotsec.org| Yes | Yes |
 |Peppermint|https://peppermintos.com | No | Yes |
 |Pop OS|https://system76.com/pop| No | Yes |
 |RancherOS|https://rancher.com/rancher-os| Yes | No |

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -861,6 +861,15 @@ endpoints:
     os: parrot
     version: current
     flavor: kde
+  parrot-security-xfce:
+    path: /debian-squash/releases/download/4.7-8ffa950d/
+    files:
+    - filesystem.squashfs
+    - initrd
+    - vmlinuz
+    os: parrot
+    version: current
+    flavor: xfce-security
   parrot-security-kde:
     path: /debian-squash/releases/download/4.7-bd06009c/
     files:

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -306,10 +306,8 @@ releases:
       8: "/repo/OracleLinux/OL8/baseos/latest/x86_64" 
   parrotsec:
     name: "Parrot Security"
-    mirror: "https://mirrordirector.archive.parrotsec.org"
-    base_dir: "parrot"
     enabled: true
-    menu: "security"
+    menu: "linux"
     versions:
       - name: "Stable Netinstall"
         code_name: "stable"

--- a/roles/netbootxyz/templates/menu/live-parrot-ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-parrot-ipxe.j2
@@ -1,0 +1,37 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Parrot OS
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "parrot" %}
+item {{ value.version }}-{{ value.flavor }} ${space} ${os} {{ value.version }} {{ value.flavor }}
+{% endif %}
+{% endfor %}
+choose live_version || goto live_exit
+goto ${live_version}
+
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "parrot" %}
+:{{ value.version }}-{{ value.flavor }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ value.path }}
+goto boot
+
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -21,6 +21,7 @@ item live-lite ${space} Linux Lite
 item live-q4os ${space} Q4OS
 item live-manjaro ${space} Manjaro
 item live-mint ${space} Mint
+item live-parrot ${space} Parrot OS
 item live-peppermint ${space} Peppermint
 item live-popos ${space} Pop OS
 item live-regolith ${space} Regolith

--- a/roles/netbootxyz/templates/menu/parrotsec.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/parrotsec.ipxe.j2
@@ -16,9 +16,10 @@ choose parrotsec_version || goto parrotsec_exit
 goto parrotsec_boot
 
 :parrotsec_boot
-set parrotsec_initrd https://mirrordirector.archive.parrotsec.org/parrot/dists/${parrotsec_version}/main/installer-${arch_a}/current/images/netboot/mini.iso
-kernel ${memdisk} iso raw
-initrd ${parrotsec_initrd}
+imgfree
+set url ${live_endpoint}{{ endpoints['parrot-net'].path }}
+kernel ${url}vmlinuz vga=788 initrd=initrd
+initrd ${url}initrd
 boot
 goto parrotsec_exit
 


### PR DESCRIPTION
We might want to think about dropping the security related menu or conversely shifting all the liveCDs and installers that are security/privacy focused into it. For this one I moved parrot to the linux installers menu. 

The Live stuff has the Vbox bug where you need to mash buttons on the initial curl, but works fine on hardware. 

Tested on virtual and hardware Bios/UEFI. 