### PR TITLE
#528 adding grml menu and assets for live booting

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 |Clonezilla|http://www.clonezilla.org/| - | Yes |
 |DBAN|http://www.dban.org/| Yes | Yes |
 |GParted|http://gparted.org| ISO - Memdisk | - |
-|Grml|http://grml.org| ISO - Memdisk | - |
+|Grml|http://grml.org| NA | Yes |
 |Memtest|http://www.memtest.org/| Yes | - |
 |Super Grub2 Disk|http://www.supergrubdisk.org| ISO - Memdisk | - |
 |Ultimate Boot CD|http://www.ultimatebootcd.com| ISO - Memdisk | - |

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -409,6 +409,10 @@ utilitiespcbios:
     type: "memdisk"
     version: "1.0.0-3"
     util_path: "http://master.dl.sourceforge.net/project/gparted/gparted-live-stable/1.0.0-3/gparted-live-1.0.0-3-amd64.iso"
+  grml:
+    name: "Grml"
+    enabled: true
+    type: "ipxemenu"
   memtest:
     name: "Memtest"
     enabled: true
@@ -432,6 +436,10 @@ utilitiespcbios:
 utilitiesefi:
   clonezilla:
     name: "Clonezilla"
+    enabled: true
+    type: "ipxemenu"
+  grml:
+    name: "Grml"
     enabled: true
     type: "ipxemenu"
 

--- a/roles/netbootxyz/templates/menu/grml.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/grml.ipxe.j2
@@ -1,0 +1,37 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os Grml
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "grml" %}
+item {{ value.version }}-{{ value.flavor }} ${space} ${os} {{ value.version }} {{ value.flavor }}
+{% endif %}
+{% endfor %}
+choose live_version || goto live_exit
+goto ${live_version}
+
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "grml" %}
+:{{ value.version }}-{{ value.flavor }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ value.path }}
+goto boot
+
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0


### PR DESCRIPTION
I only tested this in VM but it is a modern kernel should work in UEFI. 

Left the live entry in the default yml as is. 