### PR TITLE
add live asset booting for gparted

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 |Breakin|http://www.advancedclustering.com/products/software/breakin/| Yes | Yes |
 |Clonezilla|http://www.clonezilla.org/| - | Yes |
 |DBAN|http://www.dban.org/| Yes | Yes |
-|GParted|http://gparted.org| ISO - Memdisk | - |
+|GParted|http://gparted.org| NA | Yes |
 |Grml|http://grml.org| ISO - Memdisk | - |
 |Memtest|http://www.memtest.org/| Yes | - |
 |Super Grub2 Disk|http://www.supergrubdisk.org| ISO - Memdisk | - |

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -406,9 +406,7 @@ utilitiespcbios:
   gparted:
     name: "GParted"
     enabled: true
-    type: "memdisk"
-    version: "1.0.0-3"
-    util_path: "http://master.dl.sourceforge.net/project/gparted/gparted-live-stable/1.0.0-3/gparted-live-1.0.0-3-amd64.iso"
+    type: "ipxemenu"
   memtest:
     name: "Memtest"
     enabled: true
@@ -432,6 +430,10 @@ utilitiespcbios:
 utilitiesefi:
   clonezilla:
     name: "Clonezilla"
+    enabled: true
+    type: "ipxemenu"
+  gparted:
+    name: "GParted"
     enabled: true
     type: "ipxemenu"
 

--- a/roles/netbootxyz/templates/menu/gparted.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/gparted.ipxe.j2
@@ -1,0 +1,37 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os GParted Live
+menu ${os} - Current Arch [ ${arch} ]
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "gparted" %}
+item {{ value.version }} ${space} ${os} {{ value.version }}
+{% endif %}
+{% endfor %}
+choose live_version || goto live_exit
+goto ${live_version}
+
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "gparted" %}
+:{{ value.version }}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ value.path }}
+goto boot
+
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} union=overlay username=user vga=788 initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0


### PR DESCRIPTION
Single menu entry, we can do testing in the future if we choose but it is updated frequently and does not track with stable. 
Tested in VM only but it is kernel 5.2 with efi stub so should be fine. 