### PR TITLE
adding system rescue cd to the utility menu from live assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 |Memtest|http://www.memtest.org/| Yes | - |
 |Rescatux|https://www.supergrubdisk.org/rescatux/| NA | Yes |
 |Super Grub2 Disk|http://www.supergrubdisk.org| ISO - Memdisk | - |
+|System Rescue CD|http://www.system-rescue-cd.org/| NA | Yes |
 |Ultimate Boot CD|http://www.ultimatebootcd.com| ISO - Memdisk | - |
 
 ### Feedback

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -427,6 +427,10 @@ utilitiespcbios:
     type: "memdisk"
     version: "2.04s1"
     util_path: "http://master.dl.sourceforge.net/project/supergrub2/2.04s1/super_grub2_disk_2.04s1/super_grub2_disk_hybrid_2.04s1.iso"
+  systemrescue:
+    name: "System Rescue CD"
+    enabled: true
+    type: "ipxemenu"
   ubcd:
     name: "Ultimate Boot CD (UBCD)"
     enabled: true
@@ -454,6 +458,10 @@ utilitiesefi:
     type: "direct"
     kernel: "${live_endpoint}{{ endpoints.rescatux.path }}vmlinuz boot=live fetch=${live_endpoint}{{ endpoints.rescatux.path }}filesystem.squashfs selinux=1 security=selinux enforcing=0 initrd=initrd"
     initrd: "${live_endpoint}{{ endpoints.rescatux.path }}initrd"
+  systemrescue:
+    name: "System Rescue CD"
+    enabled: true
+    type: "ipxemenu"
 
 bootloaders:
   legacy:

--- a/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
@@ -1,0 +1,38 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os System Rescue CD
+menu ${os} - Current Arch [ ${arch} ]
+item --gap Currently during boot you need to press ctrl+d/ctrl+c
+item --gap repeatedly when init hangs on starting a download
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "systemrescue" %}
+item {{ value.version }} ${space} ${os} {{ value.version }}
+{% endif %}
+{% endfor %}
+choose live_version || goto live_exit
+goto ${live_version}
+
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "systemrescue" %}
+:{{ value.version }}
+set url ${live_endpoint}{{ value.path }}
+goto boot
+
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${url}vmlinuz archisobasedir=sysresccd ip=dhcp archiso_http_srv=${url} initrd=initrd
+initrd ${url}initrd
+boot
+
+:live_exit
+clear menu
+exit 0


### PR DESCRIPTION
Has the same thing as Manjaro with the boot hang, put notes in the menu. 
This is arch based and the creators actually include pxe hooks by default. 

Tested on VM bios/uefi. 