### PR TITLE
moving blackarch to live assets and pulling security entry from main menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 |Alpine Linux| https://alpinelinux.org | Yes | No |
 |Arch Linux| https://www.archlinux.org| Yes | No |
 |Backbox|https://www.backbox.org | No | Yes |
-|BlackArch Linux|https://blackarch.org| ISO - Memdisk | No |
+|BlackArch Linux|https://blackarch.org| Yes | Yes |
 |Bodhi Linux|https://www.bodhilinux.com| No | Yes |
 |CentOS| https://centos.org | Yes | No |
 |Debian| https://debian.org | Yes | Yes|

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -96,10 +96,10 @@ releases:
   blackarch:
     name: "BlackArch"
     enabled: true
-    menu: "security"
+    menu: "linux"
     versions:
-      - name: "2020.01.01"
-        code_name: "2020.01.01"
+      - name: "current"
+        code_name: "current"
   centos:
     name: "CentOS"
     mirror: "http://mirror.centos.org"

--- a/roles/netbootxyz/templates/menu/blackarch.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/blackarch.ipxe.j2
@@ -8,7 +8,8 @@ goto ${menu}
 :blackarch
 set os {{ releases.blackarch.name }}
 menu ${os} Installers
-item --gap Official Releases
+item --gap The Default login is root/blackarch
+item --gap Run blackarch-install once logged in
 {% for item in releases.blackarch.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
@@ -16,9 +17,10 @@ choose blackarch_version || goto blackarch_exit
 goto blackarch_boot
 
 :blackarch_boot
-set blackarch_initrd http://distro.ibiblio.org/blackarch/iso/blackarch-linux-netinst-${blackarch_version}-x86_64.iso
-kernel ${memdisk} iso raw
-initrd ${blackarch_initrd}
+imgfree
+set url ${live_endpoint}{{ endpoints['blackarch-installer'].path }}
+kernel ${url}vmlinuz archisobasedir=blackarch ip=dhcp archiso_http_srv=${url} initrd=initrd
+initrd ${url}initrd
 boot
 goto blackarch_exit
 

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -49,7 +49,6 @@ set menu_linux 1
 set menu_bsd 1
 set menu_freedos 1
 set menu_live 1
-set menu_security 1
 set menu_windows 1
 set menu_utils 1
 iseq ${buildarch} i386 && goto x86_64 ||

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -49,7 +49,6 @@ iseq ${menu_linux} 1 && item linux ${space} Linux Network Installs ||
 iseq ${menu_live} 1 && item live ${space} Live CDs ||
 iseq ${menu_bsd} 1 && item bsd ${space} BSD Installs ||
 iseq ${menu_freedos} 1 && item freedos ${space} FreeDOS || 
-iseq ${menu_security} 1 && item security ${space} Security Related ||
 iseq ${menu_windows} 1 && item windows ${space} Windows ||
 item --gap Tools:
 iseq ${menu_utils} 1 && item utils-${platform} ${space} Utilities ||


### PR DESCRIPTION
I left the security ipxe file in place for now, just pulled it out of the menu and the boot.cfg. 

Tested booting on VM bios/UEFI. 