### PR TITLE
Attempt other potential case changes for Windows

### DIFF
--- a/roles/netbootxyz/templates/menu/windows.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/windows.ipxe.j2
@@ -46,8 +46,10 @@ imgfree
 kernel {{ wimboot_location }}
 initrd -n bootmgr     ${win_base_url}/${win_arch}/bootmgr       bootmgr ||
 initrd -n bootmgr.efi ${win_base_url}/${win_arch}/bootmgr.efi   bootmgr.efi ||      
-initrd -n bcd         ${win_base_url}/${win_arch}/boot/bcd      bcd
-initrd -n boot.sdi    ${win_base_url}/${win_arch}/boot/boot.sdi boot.sdi   
+initrd -n bcd         ${win_base_url}/${win_arch}/boot/bcd      bcd ||
+initrd -n bcd         ${win_base_url}/${win_arch}/Boot/BCD      bcd ||
+initrd -n boot.sdi    ${win_base_url}/${win_arch}/boot/boot.sdi boot.sdi ||
+initrd -n boot.sdi    ${win_base_url}/${win_arch}/Boot/boot.sdi boot.sdi ||
 initrd -n boot.wim    ${win_base_url}/${win_arch}/sources/boot.wim boot.wim
 boot
 


### PR DESCRIPTION
WinPE and Win 10 can sometimes have variations on case,
so we attempt to load those variations.  To ensure it
always just works, ensure the files are lower case when
hosting the bits somewhere.