### PR TITLE
Allow more than one RC at given version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -112,7 +112,7 @@ jobs:
       script: skip
       before_deploy:
         - export RELEASE_TAG=$(cat version.txt)-RC
-        - git tag ${RELEASE_TAG}
+        - ./script/tag
       deploy:
         - provider: releases
           api_key: $GITHUB_TOKEN

--- a/script/tag
+++ b/script/tag
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+# if tag exists append random string to it
+CODE=$(curl -s -o /dev/null -I -w "%{http_code}" https://api.github.com/repos/netbootxyz/netboot.xyz/releases/tags/"${RELEASE_TAG}")
+echo ${CODE}
+if [ "${CODE}" == "404" ]; then
+  git tag ${RELEASE_TAG}
+elif [ "${CODE}" == "200" ]; then
+  RAND=$(cat /dev/urandom | tr -dc 'A-Z0-9' | fold -w 3 | head -n 1)
+  git tag ${RELEASE_TAG}${RAND}
+fi


### PR DESCRIPTION
I went with the entropy approach here, simplifies the logic to just checking for if it exists instead of drilling into paginated APIs in a loop. The chances for collision are pretty slim unless we push RCs with 100s of revisions. 
In the unlikely events that we need to push multiple RCs this will generate new tags if the original -RC release already exists. 

Also we should cut an RC today. 