### PR TITLE
change version display for installer update live menu

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -232,7 +232,7 @@ releases:
     enabled: true
     menu: "linux"
     versions:
-      - name: "Rolling Edition (2019.4)"
+      - name: "Rolling Edition (2020.1)"
         code_name: "rolling"
   livegrml:
     name: "Grml Live Linux"

--- a/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
@@ -15,8 +15,13 @@ goto ${live_version}
 
 :rolling
 {% for key, value in endpoints.items() | sort %}
-{% if value.os == "kali" and 'squash' in key and value.version == "rolling" %}
+{% if value.os == "kali" and 'squash' in key and value.version == "rolling" and value.flavor == "xfce" %}
 item {{ key }} ${space} {{ value.os | title }} {{ value.version | title }} {{ value.flavor | upper }}
+{% endif %}
+{% endfor %}
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "kali" and 'squash' in key and value.version == "rolling" and value.flavor != "xfce" %}
+item {{ key }} ${space} {{ value.os | title }} 2019.4 {{ value.flavor | upper }}
 {% endif %}
 {% endfor %}
 goto flavor_select

--- a/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
@@ -32,22 +32,27 @@ echo ${cls}
 goto ${flavor} ||
 
 {% for key, value in endpoints.items() | sort %}
-{% if value.os == "kali" and 'squash' in key %}
+{% if value.os == "kali" and 'squash' in key and value.flavor != "xfce" %}
 {% set kernel_name = value.kernel %}
 :{{ key }}
 set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set params components username=root hostname=kali
 {% for key, value in endpoints.items() | sort %}
 {% if key == kernel_name %}
 set kernel_url ${live_endpoint}{{ value.path }}
 {% endif %}
 {% endfor %}
 goto boot
+{% elif value.os == "kali" %}
+set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
+set kernel_url ${live_endpoint}{{ value.path }}
+set params components
 {% endif %}
 {% endfor %}
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live components username=root hostname=kali fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live ${params} fetch=${squash_url} initrd=initrd
 initrd ${kernel_url}initrd
 boot
 


### PR DESCRIPTION
Kali dropped the flavors for 2020 it looks like they only have an installer, live, and netinstaller DVD now. 

