### PR TITLE
RC v2 for 2.0.9

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -916,11 +916,12 @@ endpoints:
     os: rescatux
     version: current
   systemrescue:
-    path: /asset-mirror/releases/download/6.0.7-3ee5dc80/
+    path: /asset-mirror/releases/download/6.0.7-8bb943c9/
     files:
     - airoot.sfs
     - initrd
     - vmlinuz
+    - airootfs.sfs
     os: systemrescue
     version: current
   caine:

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -983,11 +983,12 @@ endpoints:
     os: anarchy
     version: current
   zeninstall:
-    path: /asset-mirror/releases/download/2019.10.31-b8afbdfb/
+    path: /asset-mirror/releases/download/2019.10.31-f6cb8fba/
     files:
     - airoot.sfs
     - initrd
     - vmlinuz
+    - airootfs.sfs
     os: zeninstall
     version: current
   gentoo:

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -967,11 +967,12 @@ endpoints:
     os: velt
     version: current
   bluestar:
-    path: /asset-mirror/releases/download/5.4.13-2020.01.19-3db62c8c/
+    path: /asset-mirror/releases/download/5.4.13-2020.01.19-32a0740f/
     files:
     - airoot.sfs
     - initrd
     - vmlinuz
+    - airootfs.sfs
     os: bluestar
     version: current
   anarchy:

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -768,7 +768,7 @@ endpoints:
     flavor: xfce-min
     kernel: sparky-rolling-mingui
   sparky-rolling-gui:
-    path: /debian-squash/releases/download/2020.02-d29aa310/
+    path: /debian-squash/releases/download/2020.02.1-d29aa310/
     files:
     - filesystem.squashfs
     - initrd

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -949,11 +949,12 @@ endpoints:
     os: bootrepair
     version: current
   blackarch-installer:
-    path: /asset-mirror/releases/download/2020.01.01-5e770614/
+    path: /asset-mirror/releases/download/2020.01.01-82b93b61/
     files:
     - airoot.sfs
     - initrd
     - vmlinuz
+    - airootfs.sfs
     os: blackarch
     version: current
   velt-current:

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -778,7 +778,7 @@ endpoints:
     flavor: xfce
     kernel: sparky-rolling-gui
   sparky-rolling-lxqt:
-    path: /debian-squash/releases/download/2020.02-ddb8d501/
+    path: /debian-squash/releases/download/2020.02.1-ddb8d501/
     files:
     - filesystem.squashfs
     - initrd

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -976,11 +976,12 @@ endpoints:
     os: bluestar
     version: current
   anarchy:
-    path: /asset-mirror/releases/download/1.0.10-868be963/
+    path: /asset-mirror/releases/download/1.0.10-bfbb819d/
     files:
     - airoot.sfs
     - initrd
     - vmlinuz
+    - airootfs.sfs
     os: anarchy
     version: current
   zeninstall:

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -758,7 +758,7 @@ endpoints:
     flavor: lxqt
     kernel: sparky-stable-lxqt
   sparky-rolling-mingui:
-    path: /debian-squash/releases/download/2020.02-d2988588/
+    path: /debian-squash/releases/download/2020.02.1-d2988588/
     files:
     - filesystem.squashfs
     - initrd

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -1082,7 +1082,7 @@ endpoints:
     os: raizo
     version: current
   4mlinux:
-    path: /asset-mirror/releases/download/31.1-7e63c849/
+    path: /asset-mirror/releases/download/31.2-7e63c849/
     files:
     - initrd
     - vmlinuz

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -918,7 +918,6 @@ endpoints:
   systemrescue:
     path: /asset-mirror/releases/download/6.0.7-8bb943c9/
     files:
-    - airoot.sfs
     - initrd
     - vmlinuz
     - airootfs.sfs
@@ -951,7 +950,6 @@ endpoints:
   blackarch-installer:
     path: /asset-mirror/releases/download/2020.01.01-82b93b61/
     files:
-    - airoot.sfs
     - initrd
     - vmlinuz
     - airootfs.sfs
@@ -960,7 +958,6 @@ endpoints:
   velt-current:
     path: /asset-mirror/releases/download/0.3.0-5ac90465/
     files:
-    - airoot.sfs
     - initrd
     - vmlinuz
     - airootfs.sfs
@@ -969,7 +966,6 @@ endpoints:
   bluestar:
     path: /asset-mirror/releases/download/5.4.13-2020.01.19-32a0740f/
     files:
-    - airoot.sfs
     - initrd
     - vmlinuz
     - airootfs.sfs
@@ -978,7 +974,6 @@ endpoints:
   anarchy:
     path: /asset-mirror/releases/download/1.0.10-bfbb819d/
     files:
-    - airoot.sfs
     - initrd
     - vmlinuz
     - airootfs.sfs
@@ -987,7 +982,6 @@ endpoints:
   zeninstall:
     path: /asset-mirror/releases/download/2019.10.31-f6cb8fba/
     files:
-    - airoot.sfs
     - initrd
     - vmlinuz
     - airootfs.sfs

--- a/endpoints.yml
+++ b/endpoints.yml
@@ -958,11 +958,12 @@ endpoints:
     os: blackarch
     version: current
   velt-current:
-    path: /asset-mirror/releases/download/0.3.0-9f6eb608/
+    path: /asset-mirror/releases/download/0.3.0-5ac90465/
     files:
     - airoot.sfs
     - initrd
     - vmlinuz
+    - airootfs.sfs
     os: velt
     version: current
   bluestar:


### PR DESCRIPTION
Includes a bugfix for the arch asset naming in the webapp. 
Updates assets:
Sparky rolling
4mlinux