### PR TITLE
update manjaro listing for old stable and support EFI

### DIFF
--- a/roles/netbootxyz/templates/menu/live-manjaro.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-manjaro.ipxe.j2
@@ -6,8 +6,8 @@ menu ${os} Live - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 set ipparam BOOTIF=${netX/mac} ip=dhcp net.ifnames=0
 item --gap ${os} Live versions
-item stable ${space} ${os} 18.1.0
-item current ${space} ${os} Current
+item current ${space} ${os} Current Stable (19.x)
+item stable ${space} ${os} Old Stable (18.1.0)
 choose menu || goto live_exit
 goto ${menu}
 
@@ -59,7 +59,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz misobasedir=manjaro ${ipparam} miso_http_srv=${fetch_url} nouveau.modeset=1 i915.modeset=1 radeon.modeset=1 driver=free tz=UTC lang=en_US keytable=us
+kernel ${kernel_url}vmlinuz misobasedir=manjaro ${ipparam} miso_http_srv=${fetch_url} nouveau.modeset=1 i915.modeset=1 radeon.modeset=1 driver=free tz=UTC lang=en_US keytable=us initrd=initrd
 initrd ${kernel_url}initrd
 boot
 


### PR DESCRIPTION
Swap the menu ordering and we missed UEFI support with the `initrd=initrd` line. 
I have tested architect and XFCE for the 19.x series luckly the MISO boot logic has not changes so we can use the mod layer from old stable. 