### PR TITLE
Use inst.ks for kickstart on CentOS

### DIFF
--- a/roles/netbootxyz/templates/menu/centos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/centos.ipxe.j2
@@ -48,7 +48,7 @@ goto bootos_images
 
 :kickstart
 echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
-set params ks=${ksurl} ||
+set params inst.ks=${ksurl} ||
 clear bt
 goto boottype
 


### PR DESCRIPTION
It looks like CentOS uses inst.ks now instead
of the ks option.  Updates parameter to latest
one.

Fixes https://github.com/netbootxyz/netboot.xyz/issues/583