### PR TITLE
adding LMDE mint edition to the live menu

### DIFF
--- a/roles/netbootxyz/templates/menu/live-mint.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-mint.ipxe.j2
@@ -8,6 +8,7 @@ menu ${os} - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 item --gap ${os} Versions
 item 19 ${space} ${os} 19
+item lmde ${space} ${os} LMDE
 choose live_version || goto live_exit
 menu ${os} ${live_version}
 item --gap ${os} Flavors
@@ -16,6 +17,14 @@ goto ${live_version}
 :19
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "mint" and 'squash' in key and value.version == "19" %}
+item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
+{% endif %}
+{% endfor %}
+goto flavor_select
+
+:lmde
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "mint" and value.version == "lmde" %}
 item {{ key }} ${space} {{ value.os | title }} {{ value.version }} {{ value.flavor | title}}
 {% endif %}
 {% endfor %}
@@ -43,6 +52,12 @@ goto {{ value.version }}-boot
 :19-boot
 imgfree
 kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+initrd ${kernel_url}initrd
+boot
+
+:lmde-boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
 initrd ${kernel_url}initrd
 boot
 


### PR DESCRIPTION
For the new asset in Debian Squash. 
Tested asset booting locally with snippet: 
```
:CUSTOM
imgfree
set url https://github.com/netbootxyz/debian-squash/releases/download/4-d037ef06/
kernel ${url}vmlinuz boot=live fetch=${url}filesystem.squashfs initrd=initrd
initrd ${url}initrd
boot
```

Loads up fine UEFI and bios. 