### PR TITLE
Fix utilities override

### DIFF
--- a/roles/netbootxyz/tasks/generate_menus.yml
+++ b/roles/netbootxyz/tasks/generate_menus.yml
@@ -9,15 +9,27 @@
       releases: "{{ _releases }}"
     when: release_overrides is defined
 
-  - name: Combine overrides with utilities defaults
+    # PC BIOS utilities
+  - name: Combine overrides with utilitiespcbios defaults
     set_fact:
-      _utilities: "{{ utilities|combine(utilities_overrides, recursive=True) }}"
-    when: utilities_overrides is defined
+      _utilitiespcbios: "{{ utilitiespcbios|combine(utilitiespcbios_overrides, recursive=True) }}"
+    when: utilitiespcbios_overrides is defined
 
-  - name: Set utility with user overrides
+  - name: Set utilitypcbios with user overrides
     set_fact:
-      utilities: "{{ _utilities }}"
-    when: utilities_overrides is defined
+      utilitiespcbios: "{{ _utilitiespcbios }}"
+    when: utilitiespcbios_overrides is defined
+
+    # EFI utilities
+  - name: Combine overrides with utilitiesefi defaults
+    set_fact:
+      _utilitiesefi: "{{ utilitiesefi|combine(utilitiesefi_overrides, recursive=True) }}"
+    when: utilitiesefi_overrides is defined
+
+  - name: Set utilityefi with user overrides
+    set_fact:
+      utilitiesefi: "{{ _utilitiesefi }}"
+    when: utilitiesefi_overrides is defined
 
   - name: Generate directories
     file:

--- a/user_overrides.yml
+++ b/user_overrides.yml
@@ -25,8 +25,13 @@ generate_checksums: true
 #  fedora:
 #    mirror: "mirrors.kernel.org"
 
-# set utilities_overrides from standard netboot.xyz defaults
-#utilities_overrides:
+# set utilitiesefi_overrides from standard netboot.xyz defaults for EFI utilities
+#utilitiesefi_overrides:
+#  supergrub:
+#    enabled: false
+
+# set utilities_overrides from standard netboot.xyz defaults for PC BIOS utilities
+#utilitiespcbios_overrides:
 #  supergrub:
 #    enabled: false
 


### PR DESCRIPTION
This pull request fixes the override of the "utilities" section, as it was splitted in "EFI" and "PCBIOS" in `main.yml` (`utilitiesefi` and `utilitiespcbios`) but not in `user_overrides.yml` documentation, nor in `tasks/generate_menus.yml` (Ansible role `netbootxyz`).

Also, by following the documentation in `user_overrides.yml` comments (that says to create a `utilities_override:` section) we incur in an error during the Ansible role execution of the relative task (as `utilities` is now undefined).

This pull request fixes the role and update the documentation in `user_overrides.yml`