### PR TITLE
Removes ability to test forked

### DIFF
--- a/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
@@ -9,7 +9,6 @@ item {{ key }} ${space} {{ value.name }}
 {% endfor %}
 item --gap netboot.xyz tools:
 item nbxyz-custom ${space} Set Github username [user: ${github_user}]
-item testpr ${space} Test forked netboot.xyz branch or hash
 item nbxyz ${space} netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
 echo ${cls}
@@ -36,21 +35,6 @@ echo You can then customize your fork as needed and set up your own custom optio
 echo Once your username is set, a custom option will appear on the main menu.
 echo
 echo -n Please enter your Github username: ${} && read github_user
-goto utils_exit
-
-:testpr
-clear github_user
-clear github_branch_or_hash
-echo This will chainload into a testing branch of netboot.xyz. You'll need to enter
-echo your Github username and the first part of the commit hash of the commit you want
-echo to test or the branch name. This assumes you are testing from a forked netboot.xyz
-echo repo.
-echo
-echo -n Specify Github username: ${} && read github_user
-echo -n Specify Github branch name or commit hash ( i.e. my_feature or 30b7ca ): ${} && read github_branch_or_hash
-echo
-echo Attempting to chainload branch or hash:
-chain --autofree https://raw.githubusercontent.com/${github_user}/netboot.xyz/${github_branch_or_hash}/src/menu.ipxe || echo Unable to find Github branch or hash... && sleep 5 && goto utils_exit
 goto utils_exit
 
 :utils_exit

--- a/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
@@ -10,7 +10,6 @@ item {{ key }} ${space} {{ value.name }}
 item --gap netboot.xyz tools:
 item nbxyz-custom ${space} Set Github username [user: ${github_user}]
 item testdistro ${space} Test Distribution ISO
-item testpr ${space} Test forked netboot.xyz branch or hash
 item nbxyz ${space} netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
 echo ${cls}
@@ -73,21 +72,6 @@ echo -n URL: ${} && read distro_iso
 kernel ${memdisk} iso raw
 initrd ${distro_iso}
 boot
-goto utils_exit
-
-:testpr
-clear github_user
-clear github_branch_or_hash
-echo This will chainload into a testing branch of netboot.xyz. You'll need to enter
-echo your Github username and the first part of the commit hash of the commit you want
-echo to test or the branch name. This assumes you are testing from a forked netboot.xyz
-echo repo.
-echo
-echo -n Specify Github username: ${} && read github_user
-echo -n Specify Github branch name or commit hash ( i.e. my_feature or 30b7ca ): ${} && read github_branch_or_hash
-echo
-echo Attempting to chainload branch or hash:
-chain --autofree https://raw.githubusercontent.com/${github_user}/netboot.xyz/${github_branch_or_hash}/src/menu.ipxe || echo Unable to find Github branch or hash... && sleep 5 && goto utils_exit
 goto utils_exit
 
 :utils_exit


### PR DESCRIPTION
This feature no longer works since sources are now templates,
so removing this feature.