### PR TITLE
Use non updates dir for Ubuntu 20.04

### DIFF
--- a/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
@@ -31,7 +31,7 @@ goto deb_boot_type
 :mirrorcfg
 set mirrorcfg mirror/suite=${ubuntu_version}
 set dir ${ubuntu_base_dir}/dists/${ubuntu_version}-updates/main/installer-${arch_a}/current/images/netboot/
-iseq ${ubuntu_version} eoan && set dir ${ubuntu_base_dir}/dists/${ubuntu_version}/main/installer-${arch_a}/current/images/netboot/ ||
+iseq ${ubuntu_version} focal && set dir ${ubuntu_base_dir}/dists/${ubuntu_version}/main/installer-${arch_a}/current/images/netboot/ ||
 
 :deb_boot_type
 menu ${os} [${ubuntu_version}] Installer


### PR DESCRIPTION
focal-updates isn't available yet so use regular
url.