### PR TITLE
WIP: Enable running playbook on Fedora

### DIFF
--- a/roles/netbootxyz/tasks/generate_disks_base.yml
+++ b/roles/netbootxyz/tasks/generate_disks_base.yml
@@ -16,7 +16,9 @@
     yum:
       name: epel-release
       state: present
-    when: ansible_os_family == "RedHat"
+    when:
+      - ansible_os_family == "RedHat"
+      - ansible_distribution is not "Fedora"
 
   - name: Set var to bootloader of loop
     set_fact:


### PR DESCRIPTION
Fedora includes most EPEL packages inside of their default repo, they also do not have a epel package,
including this "and not" statment will exlude Fedora from attempting to install epel
This is for #623