### PR TITLE
Enabling ansible-playbook on fedora containers

### DIFF
--- a/roles/netbootxyz/tasks/generate_disks_base.yml
+++ b/roles/netbootxyz/tasks/generate_disks_base.yml
@@ -16,7 +16,8 @@
     yum:
       name: epel-release
       state: present
-    when: ansible_os_family == "RedHat"
+    when:
+      - ansible_distribution == "CentOS"
 
   - name: Set var to bootloader of loop
     set_fact:

--- a/roles/netbootxyz/vars/redhat.yml
+++ b/roles/netbootxyz/vars/redhat.yml
@@ -9,3 +9,4 @@ netbootxyz_packages:
   - minizip-devel
   - syslinux
   - xz-devel
+  - make


### PR DESCRIPTION
Fedora Linux and RHEL do not have the EPEL repository available for them from the base install and repository, only CentOS does. Originally the playbook would fail on Fedora containers due to lack of `make` package and no `epel-release` available to install. Since Fedora includes the packages required in the base repository, skipping EPEL for Fedora is appropriate. We can do this by specifying the `ansible_distribution` var instead of `ansible_os_family` 

The `make` package was added since it is not a dependency of the original list. 