### PR TITLE
Switch to CentOS 7.x instead of version specific

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -127,8 +127,8 @@ releases:
       name: '8.0'
     - code_name: 8-stream
       name: 8.0 Stream
-    - code_name: 7.8.2003
-      name: '7.8'
+    - code_name: 7
+      name: '7.x Latest'
   coreos:
     base_dir: prod/streams/stable/builds
     enabled: true

--- a/roles/netbootxyz/templates/menu/centos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/centos.ipxe.j2
@@ -18,7 +18,7 @@ item {{ item.code_name }} ${space} ${os} {{ item.name }}
 isset ${osversion} || choose osversion || goto linux_menu
 echo ${cls}
 set dir ${centos_base_dir}/${osversion}/BaseOS/${arch}/os
-iseq ${osversion} 7.7.1908 && set dir ${centos_base_dir}/${osversion}/os/${arch} ||
+iseq ${osversion} 7 && set dir ${centos_base_dir}/${osversion}/os/${arch} ||
 set repo ${centos_mirror}/${dir}
 goto boottype
 


### PR DESCRIPTION
Switches to Centos 7.x mirror and adjusts the rule so the
correct 7.x path is used