### PR TITLE
Improved k3os install and added live-boot

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -227,11 +227,8 @@ releases:
   k3os:
     enabled: true
     menu: linux
-    mirror: https://github.com/rancher/k3os/releases/download/
+    mirror: https://github.com/rancher/k3os/releases
     name: k3OS
-    versions:
-    - code_name: v0.8.0
-      name: v0.8.0
   kali:
     base_dir: kali
     enabled: true

--- a/roles/netbootxyz/templates/menu/k3os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/k3os.ipxe.j2
@@ -7,7 +7,8 @@
 goto ${menu} ||
 
 :k3os
-set os k3OS
+set os {{ releases.k3os.name }}
+set k3os_mirror {{ releases.k3os.mirror }}
 isset ${k3os_version} || set k3os_version latest
 isset ${k3os_install_device} || set k3os_install_device /dev/sda
 menu ${os} by Rancher - ${arch_a}

--- a/roles/netbootxyz/templates/menu/k3os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/k3os.ipxe.j2
@@ -1,24 +1,76 @@
 #!ipxe
 
-# k3OS
+# k3OS by Rancher
 # https://k3os.io/
+# https://github.com/rancher/k3os#configuration-reference
 
 goto ${menu} ||
 
 :k3os
-set os {{ releases.k3os.name }}
-set k3os_mirror {{ releases.k3os.mirror }}
+set os k3OS
+isset ${k3os_version} || set k3os_version latest
+isset ${k3os_install_device} || set k3os_install_device /dev/sda
 menu ${os} by Rancher - ${arch_a}
-item --gap k3OS Versions:
-{% for item in releases.k3os.versions %}
-item {{ item.code_name }} ${space} ${os} {{ item.name }}
-{% endfor %}
-choose version || goto k3os_exit
+menu ${os} install
+item --gap k3OS:
+item k3os_boot ${space} Begin install ${os} ${k3os_version}
+item --gap Parameters:
+item k3os_version ${space} ${os} version: ${k3os_version}
+item k3os_install_device ${space} Set install device: ${k3os_install_device}
+item k3os_config_url ${space} Set config.yaml URL: ${k3os_config_url}
+item k3os_mirror ${space} Set mirror URL: ${k3os_mirror}
+choose --default ${menu} menu || goto k3os_exit
+echo ${cls}
+goto ${menu} ||
+goto k3os_exit
+
+:k3os_version 
+menu ${os} version
+item latest ${space} latest 
+item custom ${space} Set custom version
+choose --default ${version} version || goto k3os_exit
+echo ${cls}
+goto k3os_version_${version} ||
+goto k3os_exit
+
+:k3os_version_latest
+set k3os_version latest
+set k3os_base_url ${k3os_mirror}/latest/download
+goto k3os
+
+:k3os_version_custom
+clear k3os_version
+echo -n Please set k3OS version manually (in format vX.Y.Z):  && read k3os_version
+set k3os_base_url ${k3os_mirror}/download/${k3os_version}
+clear menu
+goto k3os
+
+:k3os_install_device
+echo -n Please set desired install device:  && read k3os_install_device
+clear menu
+goto k3os
+
+:k3os_mirror
+echo -n Set mirror URL:  && read k3os_mirror
+clear menu
+goto k3os_version || 
+goto k3os_exit
+
+:k3os_config_url
+echo -n Set config.yaml URL:  && read k3os_config_url
+clear menu
+goto k3os
 
 :k3os_boot
+isset ${k3os_base_url} || set k3os_base_url ${k3os_mirror}/latest/download
+set install_params k3os.install.silent=true k3os.mode=install k3os.install.config_url=${k3os_config_url} k3os.install.device=${k3os_install_device}
+set boot_params printk.devkmsg=on k3os.install.iso_url=${k3os_base_url}/k3os-${arch_a}.iso console=ttyS0 console=tty1
 imgfree
-kernel ${k3os_mirror}${version}/k3os-vmlinuz-amd64 printk.devkmsg=on k3os.mode=live k3os.install.iso_url=${k3os_mirror}${version}/k3os-amd64.iso console=ttyS0 console=tty1 initrd=k3os-initrd-amd64
-initrd ${k3os_mirror}${version}/k3os-initrd-amd64
+kernel ${k3os_base_url}/k3os-vmlinuz-${arch_a} ${install_params} ${boot_params} initrd=k3os-initrd-${arch_a}
+initrd ${k3os_base_url}/k3os-initrd-${arch_a}
+echo
+echo MD5sums:
+md5sum k3os-vmlinuz-${arch_a} k3os-initrd-${arch_a}
 boot
 
 :k3os_exit

--- a/roles/netbootxyz/templates/menu/live-k3os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-k3os.ipxe.j2
@@ -1,0 +1,59 @@
+#!ipxe
+
+goto ${menu} ||
+
+:live_menu
+set os k3OS Live
+menu ${os} by Rancher - ${arch_a}
+iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
+isset ${k3os_version} || set k3os_version latest
+menu ${os} live
+item --gap k3OS live version:
+item boot ${space} ${os} ${k3os_version} - live
+item --gap Parameters:
+item k3os_version ${space} ${os} version: ${k3os_version}
+item k3os_mirror ${space} Set mirror URL: ${k3os_mirror}
+choose --default ${menu} menu || goto live_exit
+echo ${cls}
+goto ${menu} ||
+goto live_exit
+
+:k3os_version 
+menu ${os} version
+item latest ${space} latest 
+item custom ${space} Set custom version
+choose --default ${version} version || goto live_exit
+echo ${cls}
+goto k3os_version_${version} ||
+goto live_exit
+
+:k3os_version_latest
+set k3os_version latest
+set k3os_base_url ${k3os_mirror}/latest/download
+goto live_menu
+
+:k3os_version_custom
+clear k3os_version
+echo -n Please set k3OS version manually (in format vX.Y.Z):  && read k3os_version
+set k3os_base_url ${k3os_mirror}/download/${k3os_version}
+clear menu
+goto live_menu
+
+:k3os_mirror
+echo -n Set mirror URL:  && read k3os_mirror
+clear menu
+goto k3os_version || 
+goto live_exit
+
+:boot
+isset ${k3os_base_url} || set k3os_base_url ${k3os_mirror}/latest/download
+set install_params k3os.mode=live
+set boot_params printk.devkmsg=on console=ttyS0 console=tty1
+imgfree
+kernel ${k3os_base_url}/k3os-vmlinuz-${arch_a} ${install_params} ${boot_params} initrd=k3os-initrd-${arch_a}
+initrd ${k3os_base_url}/k3os-initrd-${arch_a}
+boot
+
+:live_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/live-k3os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-k3os.ipxe.j2
@@ -3,7 +3,8 @@
 goto ${menu} ||
 
 :live_menu
-set os k3OS Live
+set os {{ releases.k3os.name }}
+set k3os_mirror {{ releases.k3os.mirror }}
 menu ${os} by Rancher - ${arch_a}
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
 isset ${k3os_version} || set k3os_version latest

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -16,6 +16,7 @@ item live-elementary ${space} elementary OS
 item live-fatdog ${space} Fatdog64
 item live-fedora ${space} Fedora
 item live-feren ${space} Feren OS
+item live-k3os ${space} K3OS
 item live-kali ${space} Kali
 item live-kodachi ${space} Kodachi
 item live-neon ${space} KDE Neon


### PR DESCRIPTION
Added customizable parameters (see image attached below):
![image 1](https://user-images.githubusercontent.com/6001344/84206834-4bbf0f80-aab0-11ea-8831-303e808cc4a7.PNG)
- version of k3os to install (defaults to latest, taken directly from github, no update needed for latest version, it will be always latest, using release tags. Specific version can also be defined, for example v0.10.2 or v0.10.1) (see image attached below).
![2](https://user-images.githubusercontent.com/6001344/84206837-4c57a600-aab0-11ea-8bec-4e4af17015be.PNG)
- install device (defaults to /dev/sda)
- config.yaml url (empty as default): url for the installation yaml (see [sample-config](https://github.com/rancher/k3os#sample-configyaml) ) 
- mirror url (defaults to github releases page): can be modified if you self-host the files (note: the structure must match the same used by github releases page)

A "custom" installation example can be viewed in image below.
![3](https://user-images.githubusercontent.com/6001344/84206838-4c57a600-aab0-11ea-85b4-b8e415360571.PNG)


A live-boot version of K3OS is also added to live-boot menu (some parameters can be modified before booting).
![4](https://user-images.githubusercontent.com/6001344/84206840-4cf03c80-aab0-11ea-82ec-29b3cf90d2b3.PNG)