### PR TITLE
Make boot_timeout configurable from boot.cfg

### DIFF
--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -22,6 +22,9 @@ set sigs {{ sigs_location }}
 # set location of latest iPXE
 iseq ${platform} efi && set ipxe_disk netboot.xyz-snponly.efi || set ipxe_disk netboot.xyz-undionly.kpxe
 
+# set default boot timeout
+set boot_timeout {{ boot_timeout }}
+
 ######################################
 # Media Locations for Licensed Distros
 ######################################

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -73,7 +73,7 @@ isset ${github_user} && item custom-github ${space} ${github_user}'s Custom Menu
 item --gap Custom User Menus: ||
 item custom-user ${space} Custom User Menus
 {% endif %}
-isset ${menu} && set timeout 0 || set timeout {{ boot_timeout }}
+isset ${menu} && set timeout 0 || set timeout ${boot_timeout}
 choose --timeout ${timeout} --default ${menu} menu || goto local
 echo ${cls}
 goto ${menu} ||


### PR DESCRIPTION
Adds a setting in boot.cfg so that the boot_timeout can
be adjusted as needed.  Moves the generated variable to
boot.cfg and is then consumed as an iPXE variable in
menu.ipxe.

Closes: https://github.com/netbootxyz/netboot.xyz/issues/654