### PR TITLE
Add imgfree before loading NixOS images

### DIFF
--- a/roles/netbootxyz/templates/menu/nixos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/nixos.ipxe.j2
@@ -11,6 +11,7 @@ item 19.09 ${space} ${os} 19.09
 choose version || goto nixos_exit
 iseq ${version} 20.03 && set link ${live_endpoint}{{ endpoints["nixos-20.03"].path }}netboot.ipxe ||
 iseq ${version} 19.09 && set link ${live_endpoint}{{ endpoints["nixos-19.09"].path }}netboot.ipxe ||
+imgfree
 chain ${link}
 goto nixos_exit
 


### PR DESCRIPTION
Should allow for images to load without panic

Fixes: https://github.com/netbootxyz/netboot.xyz/issues/657