### PR TITLE
Add an example of using custom menus with the Docker build

### DIFF
--- a/etc/netbootxyz/custom/README.md
+++ b/etc/netbootxyz/custom/README.md
@@ -22,3 +22,11 @@ a menu.  You can copy the custom directory from the repo:
 ```
 cp etc/netbootxyz/custom /etc/netbootxyz/custom
 ```
+
+If you are building via Docker, you can create a `custom` folder in
+the root source directory and then set the variable like so:
+
+```
+custom_generate_menus: true
+custom_templates_dir: "/ansible/custom"
+```


### PR DESCRIPTION
The current documentation under `/etc/netbootxyz/custom` gives an example of adding custom menus if the end-user is running the playbook locally. However, these instructions are not applicable when using the Docker build as the user does not have the ability to modify the filesystem on the Docker container without manually editing the build file. 

This PR adds an example of how to configure the `custom_templates_dir` variable to have the custom menus built when using Docker. 