### PR TITLE
Adds various Fedora CoreOS Channels

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -138,8 +138,12 @@ releases:
     mirror: https://builds.coreos.fedoraproject.org
     name: Fedora CoreOS
     versions:
-    - code_name: 31.20200113.3.1
-      name: '31'
+    - code_name: 32.20200629.3.0
+      name: 'Stable'
+    - code_name: 32.20200629.2.0
+      name: 'Testing'
+    - code_name: 32.20200625.1.0
+      name: 'Next'
   debian:
     archive_mirror: http://archive.debian.org
     base_dir: debian

--- a/roles/netbootxyz/templates/menu/coreos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/coreos.ipxe.j2
@@ -19,6 +19,8 @@ item install_dev ${space} Set install device: ${install_device}
 item ignition_config ${space} Set ignition config url: ${ignition_url}
 choose --default ${core_version} core_version || goto coreos_exit
 echo ${cls}
+iseq ${core_version} ignition_config && goto ignition_config ||
+iseq ${core_version} install_dev && goto install_dev ||
 goto core_boot ||
 goto coreos_exit
 


### PR DESCRIPTION
Adds channels for Stable, Testing, Next
Also fixes bug where CoreOS settings were being ignored

Closes https://github.com/netbootxyz/netboot.xyz/issues/672