### PR TITLE
Adds support for adding cmdline options

### DIFF
--- a/roles/netbootxyz/templates/menu/4mlinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/4mlinux.ipxe.j2
@@ -27,7 +27,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz root=/dev/ram0 vga=normal initrd=initrd
+kernel ${url}vmlinuz root=/dev/ram0 vga=normal initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/alpinelinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/alpinelinux.ipxe.j2
@@ -24,7 +24,7 @@ set base-url ${alpinelinux_mirror}
 set dir ${alpinelinux_base_dir}/${alpine_version}/releases/${bootarch}/netboot
 set repo-url ${alpinelinux_mirror}/${alpinelinux_base_dir}/${alpine_version}/main
 imgfree
-kernel ${base-url}/${dir}/vmlinuz-lts ${ipparam} alpine_repo=${repo-url} modules=loop,squashfs modloop=${base-url}/${dir}/modloop-lts quiet nomodeset
+kernel ${base-url}/${dir}/vmlinuz-lts ${ipparam} alpine_repo=${repo-url} modules=loop,squashfs modloop=${base-url}/${dir}/modloop-lts quiet nomodeset ${cmdline}
 initrd ${base-url}/${dir}/initramfs-lts
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/anarchy.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/anarchy.ipxe.j2
@@ -18,7 +18,7 @@ goto anarchy_boot
 :anarchy_boot
 imgfree
 set url ${live_endpoint}{{ endpoints.anarchy.path }}
-kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} initrd=initrd
+kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 goto anarchy_exit

--- a/roles/netbootxyz/templates/menu/archlinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/archlinux.ipxe.j2
@@ -32,7 +32,7 @@ goto boot
 :boot
 imgfree
 set dir ${archlinux_base_dir}/iso/${arch_version}/arch/boot
-set params initrd=archiso.img archiso_http_srv=http://${real_archlinux_mirror}/${archlinux_base_dir}/iso/${arch_version}/ archisobasedir=arch verify=y ${ipparam} net.ifnames=0 ${console}
+set params initrd=archiso.img archiso_http_srv=http://${real_archlinux_mirror}/${archlinux_base_dir}/iso/${arch_version}/ archisobasedir=arch verify=y ${ipparam} net.ifnames=0 ${cmdline}
 kernel http://${archlinux_mirror}/${dir}/x86_64/vmlinuz ${params} initrd=archiso.img
 initrd http://${archlinux_mirror}/${dir}/x86_64/archiso.img
 echo

--- a/roles/netbootxyz/templates/menu/blackarch.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/blackarch.ipxe.j2
@@ -20,7 +20,7 @@ goto blackarch_boot
 :blackarch_boot
 imgfree
 set url ${live_endpoint}{{ endpoints['blackarch-installer'].path }}
-kernel ${url}vmlinuz archisobasedir=blackarch ${ipparam} archiso_http_srv=${url} initrd=initrd
+kernel ${url}vmlinuz archisobasedir=blackarch ${ipparam} archiso_http_srv=${url} initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 goto blackarch_exit

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -88,7 +88,7 @@ iseq ${ipxe_cloud_config} packet && goto packet ||
 goto clouds_end
 
 :gce
-set console console=ttyS0,115200n8
+set cmdline console=ttyS0,115200n8
 goto clouds_end
 
 :packet
@@ -98,7 +98,7 @@ iseq ${buildarch} arm64 && goto packet_arm64 ||
 goto clouds_end
 
 :packet_x86_64
-set console console=ttyS1,115200n8
+set cmdline console=ttyS1,115200n8
 iseq ${platform} efi && set ipxe_disk netboot.xyz-packet.efi || set ipxe_disk netboot.xyz-packet.kpxe
 set menu_freedos 0
 set menu_windows 0
@@ -106,7 +106,7 @@ set menu_utils 0
 goto clouds_end
 
 :packet_arm64
-set console console=ttyAMA0,115200
+set cmdline console=ttyAMA0,115200
 set ipxe_disk netboot.xyz-packet-arm64.efi
 set menu_bsd 0
 set menu_freedos 0

--- a/roles/netbootxyz/templates/menu/centos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/centos.ipxe.j2
@@ -60,7 +60,7 @@ goto boottype
 
 :bootos_images
 imgfree
-kernel ${centos_mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${console} ${ipparam} initrd=initrd.img
+kernel ${centos_mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${ipparam} initrd=initrd.img ${cmdline} 
 initrd ${centos_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/clonezilla.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/clonezilla.ipxe.j2
@@ -35,7 +35,7 @@ goto clonezilla-boot
 :clonezilla-boot
 imgfree
 set url ${live_endpoint}${path}
-kernel ${url}vmlinuz boot=live username=user union=overlay config components noswap edd=on nomodeset ocs_live_run="ocs-live-general" ocs_live_batch=no net.ifnames=0 nosplash noprompt fetch=${url}filesystem.squashfs initrd=initrd
+kernel ${url}vmlinuz boot=live username=user union=overlay config components noswap edd=on nomodeset ocs_live_run="ocs-live-general" ocs_live_batch=no net.ifnames=0 nosplash noprompt fetch=${url}filesystem.squashfs initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/coreos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/coreos.ipxe.j2
@@ -31,7 +31,7 @@ iseq ${core_version} {{ item.code_name }} && set coreos_channel {{ item.name }} 
 set base_url ${coreos_mirror}/${coreos_base_dir}/${coreos_channel}/builds
 set build_version ${core_version}
 imgfree
-kernel ${base_url}/${build_version}/x86_64/fedora-coreos-${build_version}-live-kernel-x86_64 ip=dhcp rd.neednet=1 coreos.inst.install_dev=${install_device} coreos.inst.ignition_url=${ignition_url} ${console} initrd=fedora-coreos-${build_version}-live-initramfs.x86_64.img
+kernel ${base_url}/${build_version}/x86_64/fedora-coreos-${build_version}-live-kernel-x86_64 ip=dhcp rd.neednet=1 coreos.inst.install_dev=${install_device} coreos.inst.ignition_url=${ignition_url} initrd=fedora-coreos-${build_version}-live-initramfs.x86_64.img ${cmdline}
 initrd ${base_url}/${build_version}/x86_64/fedora-coreos-${build_version}-live-initramfs.x86_64.img
 boot
 goto coreos_exit

--- a/roles/netbootxyz/templates/menu/dban.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/dban.ipxe.j2
@@ -30,7 +30,7 @@ goto dban_boot
 
 :dban_boot
 imgfree
-kernel ${kernel_url} nuke="dwipe --autonuke --method ${nuke_method}" silent vga=785
+kernel ${kernel_url} nuke="dwipe --autonuke --method ${nuke_method}" silent vga=785 ${cmdline}
 boot
 
 :dban_exit

--- a/roles/netbootxyz/templates/menu/debian.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/debian.ipxe.j2
@@ -77,7 +77,7 @@ goto deb_boot
 :deb_boot
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel ${debian_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
+kernel ${debian_mirror}/${dir}/linux ${install_params} ${netcfg} ${mirrorcfg} -- quiet ${params} initrd=initrd.gz ${cmdline}
 initrd ${debian_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/devuan.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/devuan.ipxe.j2
@@ -64,7 +64,7 @@ goto devuan_boot
 :devuan_boot
 imgfree
 echo Boot parameters: ${install_params} -- quiet ${params}
-kernel ${devuan_mirror}/${dir}/linux ${install_params} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
+kernel ${devuan_mirror}/${dir}/linux ${install_params} ${mirrorcfg} -- quiet ${params} initrd=initrd.gz ${cmdline}
 initrd ${devuan_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/fedora.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/fedora.ipxe.j2
@@ -61,7 +61,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${fedora_mirror}/${dir}/images/pxeboot/vmlinuz repo=${fedora_mirror}/${dir} ${params} ${console} ${ipparam} initrd=initrd.img
+kernel ${fedora_mirror}/${dir}/images/pxeboot/vmlinuz repo=${fedora_mirror}/${dir} ${params} ${ipparam} initrd=initrd.img ${cmdline}
 initrd ${fedora_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/flatcar.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/flatcar.ipxe.j2
@@ -28,7 +28,7 @@ goto flatcar_exit
 :edge
 set release ${menu}
 set base-url http://${release}.release.flatcar-linux.net/amd64-usr/current
-kernel ${base-url}/flatcar_production_pxe.vmlinuz ${flatcar_firstboot} ${flatcar_params} ${console} flatcar.autologin=tty1 flatcar.autologin=ttyS0 initrd=flatcar_production_pxe_image.cpio.gz
+kernel ${base-url}/flatcar_production_pxe.vmlinuz ${flatcar_firstboot} ${flatcar_params} flatcar.autologin=tty1 flatcar.autologin=ttyS0 initrd=flatcar_production_pxe_image.cpio.gz ${cmdline}
 initrd ${base-url}/flatcar_production_pxe_image.cpio.gz
 boot
 goto flatcar_exit

--- a/roles/netbootxyz/templates/menu/gentoo.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/gentoo.ipxe.j2
@@ -29,7 +29,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz ip=dhcp root=/dev/ram0 init=/linuxrc loop=/image.squashfs looptype=squashfs cdroot=1 real_root=/ fetch=${url}image.squashfs initrd=initrd
+kernel ${url}vmlinuz ip=dhcp root=/dev/ram0 init=/linuxrc loop=/image.squashfs looptype=squashfs cdroot=1 real_root=/ fetch=${url}image.squashfs initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/gparted.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/gparted.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} union=overlay username=user vga=788 initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} union=overlay username=user vga=788 initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/grml.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/grml.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/ipfire.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/ipfire.ipxe.j2
@@ -19,7 +19,7 @@ goto ipfire_images
 
 :ipfire_images
 imgfree
-kernel ${ipfire_mirror}/${dir}/vmlinuz ${console} vga=791 initrd=instroot
+kernel ${ipfire_mirror}/${dir}/vmlinuz vga=791 initrd=instroot ${cmdline}
 initrd ${ipfire_mirror}/${dir}/instroot
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/k3os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/k3os.ipxe.j2
@@ -67,7 +67,7 @@ isset ${k3os_base_url} || set k3os_base_url ${k3os_mirror}/latest/download
 set install_params k3os.install.silent=true k3os.mode=install k3os.install.config_url=${k3os_config_url} k3os.install.device=${k3os_install_device}
 set boot_params printk.devkmsg=on k3os.install.iso_url=${k3os_base_url}/k3os-${arch_a}.iso console=ttyS0 console=tty1
 imgfree
-kernel ${k3os_base_url}/k3os-vmlinuz-${arch_a} ${install_params} ${boot_params} initrd=k3os-initrd-${arch_a}
+kernel ${k3os_base_url}/k3os-vmlinuz-${arch_a} ${install_params} ${boot_params} initrd=k3os-initrd-${arch_a} ${cmdline}
 initrd ${k3os_base_url}/k3os-initrd-${arch_a}
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/kali.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/kali.ipxe.j2
@@ -28,7 +28,7 @@ goto deb_boot
 
 :deb_boot
 imgfree
-kernel ${kali_mirror}/${dir}/linux vga=788 ${console} -- quiet initrd=initrd.gz
+kernel ${kali_mirror}/${dir}/linux vga=788 -- quiet initrd=initrd.gz ${cmdline}
 initrd ${kali_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/kaspersky.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/kaspersky.ipxe.j2
@@ -27,7 +27,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz netboot=${url} loadsrm=000-core.srm,001-xorg.srm,002-xfce.srm,003-kl.srm,004-krt.srm,005-bases.srm,008-firefox.srm net.ifnames=0 dodhcp dostartx initrd=initrd.xz initrd=initrd
+kernel ${url}vmlinuz netboot=${url} loadsrm=000-core.srm,001-xorg.srm,002-xfce.srm,003-kl.srm,004-krt.srm,005-bases.srm,008-firefox.srm net.ifnames=0 dodhcp dostartx initrd=initrd.xz initrd=initrd ${cmdline}
 initrd ${url}initrd.xz
 initrd ${url}initrd
 boot

--- a/roles/netbootxyz/templates/menu/live-backbox.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-backbox.ipxe.j2
@@ -28,13 +28,13 @@ goto {{ value.version }}-boot
 
 :6-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :7-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-bluestar.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-bluestar.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} cow_spacesize=30% cow_label=BSLX_PERSIST ipv6.disable=1 disablehooks=v86d,915resolution,gma3600 modprobe.blacklist=uvesafb console=tty1 initrd=initrd
+kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} cow_spacesize=30% cow_label=BSLX_PERSIST ipv6.disable=1 disablehooks=v86d,915resolution,gma3600 modprobe.blacklist=uvesafb console=tty1 initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-bodhi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-bodhi.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-debian.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-debian.ipxe.j2
@@ -50,7 +50,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-deepin.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-deepin.ipxe.j2
@@ -18,7 +18,7 @@ goto 15-boot
 
 :15-boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} union=overlay initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} union=overlay initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-devuan.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-devuan.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live username=devuan fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live username=devuan fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-elementary.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-elementary.ipxe.j2
@@ -27,7 +27,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper maybe-ubiquity netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper maybe-ubiquity netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-fatdog.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-fatdog.ipxe.j2
@@ -27,7 +27,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz rootfstype=ramfs initrd=initrd
+kernel ${url}vmlinuz rootfstype=ramfs initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-fedora.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-fedora.ipxe.j2
@@ -48,7 +48,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${live_url}vmlinuz ${ipparam} root=live:${live_url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd
+kernel ${live_url}vmlinuz ${ipparam} root=live:${live_url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd ${cmdline}
 initrd ${live_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-feren.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-feren.ipxe.j2
@@ -26,7 +26,7 @@ goto feren-boot
 imgfree
 set squash_url ${live_endpoint}${path}filesystem.squashfs
 set kernel_url ${live_endpoint}${path}
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-k3os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-k3os.ipxe.j2
@@ -51,7 +51,7 @@ isset ${k3os_base_url} || set k3os_base_url ${k3os_mirror}/latest/download
 set install_params k3os.mode=live
 set boot_params printk.devkmsg=on console=ttyS0 console=tty1
 imgfree
-kernel ${k3os_base_url}/k3os-vmlinuz-${arch_a} ${install_params} ${boot_params} initrd=k3os-initrd-${arch_a}
+kernel ${k3os_base_url}/k3os-vmlinuz-${arch_a} ${install_params} ${boot_params} initrd=k3os-initrd-${arch_a} ${cmdline}
 initrd ${k3os_base_url}/k3os-initrd-${arch_a}
 boot
 

--- a/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
@@ -52,7 +52,7 @@ set params components
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live ${params} fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live ${params} fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-kodachi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-kodachi.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-lite.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-lite.ipxe.j2
@@ -25,12 +25,12 @@ goto boot-5
 
 :boot-4
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} username=linuxlite userfullname=linuxlite initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} username=linuxlite userfullname=linuxlite initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :boot-5
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} username=linuxlite userfullname=linuxlite initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} username=linuxlite userfullname=linuxlite initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-lxle.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-lxle.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-manjaro.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-manjaro.ipxe.j2
@@ -59,7 +59,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz misobasedir=manjaro ${ipparam} miso_http_srv=${fetch_url} nouveau.modeset=1 i915.modeset=1 radeon.modeset=1 driver=free tz=UTC lang=en_US keytable=us initrd=initrd
+kernel ${kernel_url}vmlinuz misobasedir=manjaro ${ipparam} miso_http_srv=${fetch_url} nouveau.modeset=1 i915.modeset=1 radeon.modeset=1 driver=free tz=UTC lang=en_US keytable=us initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-mint.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-mint.ipxe.j2
@@ -60,19 +60,19 @@ goto {{ value.version }}-boot
 
 :20-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :19-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :lmde-boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline} 
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-neon.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-neon.ipxe.j2
@@ -18,7 +18,7 @@ goto user-boot
 
 :user-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd.lz
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd.lz ${cmdline}
 initrd ${kernel_url}initrd.lz
 boot
 

--- a/roles/netbootxyz/templates/menu/live-nitrux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-nitrux.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-parrot.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-parrot.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-peppermint.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-peppermint.ipxe.j2
@@ -27,7 +27,7 @@ goto {{ value.version }}-boot
 
 :10-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-popos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-popos.ipxe.j2
@@ -60,19 +60,19 @@ goto {{ value.version }}-boot
 
 :18.04-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :19.10-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :20.04-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-q4os.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-q4os.ipxe.j2
@@ -51,7 +51,7 @@ goto q4os-boot
 
 :q4os-boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-raizo.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-raizo.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-regolith.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-regolith.ipxe.j2
@@ -18,7 +18,7 @@ goto current-boot
 
 :current-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-septor.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-septor.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-sparky.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-sparky.ipxe.j2
@@ -47,7 +47,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-ubuntu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-ubuntu.ipxe.j2
@@ -60,19 +60,19 @@ goto {{ value.version }}-boot
 
 :18.04-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :19.10-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
 :20.04-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-velt.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-velt.ipxe.j2
@@ -28,7 +28,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} initrd=initrd
+kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-voyager.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-voyager.ipxe.j2
@@ -18,7 +18,7 @@ goto ${live_version}
 set squash_url ${live_endpoint}{{ endpoints["voyager-focal-squash"].path }}filesystem.squashfs
 set kernel_url ${live_endpoint}{{ endpoints["voyager-focal-squash"].path }}
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
@@ -26,7 +26,7 @@ boot
 set squash_url ${live_endpoint}{{ endpoints["voyager-bionic-squash"].path }}filesystem.squashfs
 set kernel_url ${live_endpoint}{{ endpoints["voyager-bionic-squash"].path }}
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
@@ -34,7 +34,7 @@ boot
 set squash_url ${live_endpoint}{{ endpoints["voyager-buster-squash"].path }}filesystem.squashfs
 set kernel_url ${live_endpoint}{{ endpoints["voyager-buster-squash"].path }}
 imgfree
-kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz boot=live fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 
@@ -42,7 +42,7 @@ boot
 set squash_url ${live_endpoint}{{ endpoints["voyager-eoan-squash"].path }}filesystem.squashfs
 set kernel_url ${live_endpoint}{{ endpoints["voyager-eoan-squash"].path }}
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=url url=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/live-zorin.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-zorin.ipxe.j2
@@ -42,7 +42,7 @@ goto {{ value.version }}-boot
 
 :15-boot
 imgfree
-kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd
+kernel ${kernel_url}vmlinuz ip=dhcp boot=casper netboot=http fetch=${squash_url} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/mageia.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/mageia.ipxe.j2
@@ -24,7 +24,7 @@ set automatic method:http,network:${network},server:${mageia_mirror},directory:/
 imgfree
 kernel ${mageia_mirror}/${dir}/${dir2}/vmlinuz
 initrd ${mageia_mirror}/${dir}/${dir2}/all.rdz
-imgargs vmlinuz automatic=${automatic} vga=788 splash=silent ${console} initrd=all.rdz
+imgargs vmlinuz automatic=${automatic} vga=788 splash=silent initrd=all.rdz ${cmdline}
 echo
 echo MD5sums:
 md5sum vmlinuz all.rdz

--- a/roles/netbootxyz/templates/menu/opensuse.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/opensuse.ipxe.j2
@@ -68,7 +68,7 @@ iseq ${version} tumbleweed && set dir ${version}/repo/oss ||
 imgfree
 kernel ${opensuse_mirror}/${dir}/boot/x86_64/loader/linux
 initrd ${opensuse_mirror}/${dir}/boot/x86_64/loader/initrd
-imgargs linux ${netsetup} install=${opensuse_mirror}/${dir} ${params} ${console} initrd=initrd
+imgargs linux ${netsetup} install=${opensuse_mirror}/${dir} ${params} initrd=initrd ${cmdline}
 echo
 echo MD5sums:
 md5sum linux initrd

--- a/roles/netbootxyz/templates/menu/oracle.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/oracle.ipxe.j2
@@ -31,7 +31,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz ${ipparam} repo=${repo} root=live:${url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd
+kernel ${url}vmlinuz ${ipparam} repo=${repo} root=live:${url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/parrotsec.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/parrotsec.ipxe.j2
@@ -18,7 +18,7 @@ goto parrotsec_boot
 :parrotsec_boot
 imgfree
 set url ${live_endpoint}{{ endpoints['parrot-net'].path }}
-kernel ${url}vmlinuz vga=788 initrd=initrd
+kernel ${url}vmlinuz vga=788 initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 goto parrotsec_exit

--- a/roles/netbootxyz/templates/menu/rancheros.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rancheros.ipxe.j2
@@ -20,7 +20,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}/${folder}/vmlinuz rancher.autologin=tty1 initrd=initrd
+kernel ${url}/${folder}/vmlinuz rancher.autologin=tty1 initrd=initrd ${cmdline}
 initrd ${url}/${folder}/initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/rhel.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rhel.ipxe.j2
@@ -49,7 +49,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz repo=${rhel_base_url}/os/${rhel_arch} ${console} ${ipparam} ${params} initrd=initrd.img
+kernel ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz repo=${rhel_base_url}/os/${rhel_arch} ${ipparam} ${params} initrd=initrd.img ${cmdline}
 initrd ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/initrd.img
 md5sum vmlinuz initrd.img
 boot

--- a/roles/netbootxyz/templates/menu/scientific.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/scientific.ipxe.j2
@@ -49,7 +49,7 @@ goto bootos_images
 
 :bootos_images
 imgfree
-kernel ${scientific_mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${console} ${ipparam}
+kernel ${scientific_mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${ipparam} ${cmdline}
 initrd ${scientific_mirror}/${dir}/images/pxeboot/initrd.img
 boot
 goto linux_menu

--- a/roles/netbootxyz/templates/menu/slackware.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/slackware.ipxe.j2
@@ -26,6 +26,6 @@ goto boot
 imgfree
 kernel ${slackware_mirror}/${dir}/kernels/huge.s/bzImage
 initrd ${slackware_mirror}/${dir}/isolinux/initrd.img
-imgargs bzImage load_ramdisk=1 prompt_ramdisk=0 rw printk.time=0 SLACK_KERNEL=huge.s ${params} ${console}
+imgargs bzImage load_ramdisk=1 prompt_ramdisk=0 rw printk.time=0 SLACK_KERNEL=huge.s ${params} ${cmdline}
 isset ${debug} && prompt ||
 boot

--- a/roles/netbootxyz/templates/menu/smartos.ipxe
+++ b/roles/netbootxyz/templates/menu/smartos.ipxe
@@ -39,7 +39,7 @@ goto smartos_boot
 :smartos_boot
 iseq ${kmdb_e} true && set kflags:hex 2d:6b ||
 iseq ${kmdb_b} true && set kflags:hex 2d:6b:64 ||
-kernel ${smartos_mirror}${smartos_build}${smartos_base_dir}kernel/amd64/unix ${kflags:string} -B console=text,text-mode="115200,8,n,1,-",smartos=true,noimport=${noimport}${root_shadow:string}
+kernel ${smartos_mirror}${smartos_build}${smartos_base_dir}kernel/amd64/unix ${kflags:string} -B console=text,text-mode="115200,8,n,1,-",smartos=true,noimport=${noimport}${root_shadow:string} ${cmdline}
 module ${smartos_mirror}${smartos_build}${smartos_base_dir}amd64/boot_archive type=rootfs name=ramdisk || goto fail
 module ${smartos_mirror}${smartos_build}${smartos_base_dir}amd64/boot_archive.hash type=hash name=ramdisk || goto fail
 boot

--- a/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
@@ -30,7 +30,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz archisobasedir=sysresccd ${ipparam} archiso_http_srv=${url} initrd=initrd
+kernel ${url}vmlinuz archisobasedir=sysresccd ${ipparam} archiso_http_srv=${url} initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/talos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/talos.ipxe.j2
@@ -8,8 +8,6 @@ goto ${menu} ||
 
 :talos
 set os {{ releases.talos.name }}
-set console_arg console=tty0 console=ttyS0
-iseq ${ipxe_cloud_config} packet && set console_arg console=ttyS1,115200n8 ||
 isset ${talos_version} || set talos_version latest
 isset ${talos_mirror} || set talos_mirror {{ releases.talos.mirror }}
 isset ${talos_platform} || set talos_platform metal
@@ -69,7 +67,7 @@ goto talos
 :talos_boot
 isset ${talos_base_url} || set talos_base_url ${talos_mirror}/latest/download
 isset ${talos_config_url} && set talos_config talos.config=${talos_config_url} ||
-set boot_params initrd=initramfs.xz page_poison=1 printk.devkmsg=on slab_nomerge slub_debug=P pti=on talos.platform=${talos_platform} ${console_arg} ${talos_config}
+set boot_params initrd=initramfs.xz page_poison=1 printk.devkmsg=on slab_nomerge slub_debug=P pti=on talos.platform=${talos_platform} ${talos_config} ${cmdline}
 imgfree
 kernel ${talos_base_url}/vmlinuz ${boot_params}
 initrd ${talos_base_url}/initramfs.xz

--- a/roles/netbootxyz/templates/menu/tinycore.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/tinycore.ipxe.j2
@@ -46,7 +46,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${kernel_url} loglevel=3 initrd=${initrd_name}
+kernel ${kernel_url} loglevel=3 initrd=${initrd_name} ${cmdline}
 initrd ${initrd_url}
 boot
 

--- a/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
@@ -61,7 +61,7 @@ goto deb_boot
 :deb_boot
 set dir ${dir}${menu}-installer/${arch_a}
 imgfree
-kernel ${ubuntu_mirror}/${dir}/linux ${install_params} ${mirrorcfg} ${console} -- quiet ${params} initrd=initrd.gz
+kernel ${ubuntu_mirror}/${dir}/linux ${install_params} ${mirrorcfg} -- quiet ${params} initrd=initrd.gz ${cmdline}
 initrd ${ubuntu_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
@@ -1,5 +1,6 @@
 #!ipxe
 
+:utils_menu
 menu Utilities
 item --gap Utilities:
 {% for key, value in utilitiesefi.items() | sort(attribute='1.name') %}
@@ -8,6 +9,7 @@ item {{ key }} ${space} {{ value.name }}
 {% endif %}
 {% endfor %}
 item --gap netboot.xyz tools:
+item cmdline ${space} Kernel cmdline params: [${cmdline}]
 item nbxyz-custom ${space} Set Github username [user: ${github_user}]
 item nbxyz ${space} netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
@@ -27,6 +29,15 @@ goto utils_exit
 {% endif %}
 {% endfor %}
 
+:cmdline
+echo If you want to change the default kernel command line parameters
+echo you can override the defaults here.
+echo
+echo Currently set to: ${cmdline}
+echo
+echo -n Enter cmdline parameters: ${} && read cmdline
+goto utils_menu
+
 :nbxyz-custom
 echo EXPERIMENTAL
 echo 
@@ -35,7 +46,7 @@ echo You can then customize your fork as needed and set up your own custom optio
 echo Once your username is set, a custom option will appear on the main menu.
 echo
 echo -n Please enter your Github username: ${} && read github_user
-goto utils_exit
+goto utils_menu
 
 :utils_exit
 clear menu

--- a/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
@@ -1,5 +1,6 @@
 #!ipxe
 
+:utils_menu
 menu Utilities
 item --gap Utilities:
 {% for key, value in utilitiespcbios.items() | sort(attribute='1.name') %}
@@ -8,6 +9,7 @@ item {{ key }} ${space} {{ value.name }}
 {% endif %}
 {% endfor %}
 item --gap netboot.xyz tools:
+item cmdline ${space} Kernel cmdline params: [${cmdline}]
 item nbxyz-custom ${space} Set Github username [user: ${github_user}]
 item testdistro ${space} Test Distribution ISO
 item nbxyz ${space} netboot.xyz endpoints
@@ -48,21 +50,28 @@ md5sum memdisk ${util_file}
 boot
 goto utils_exit
 
+:cmdline
+echo If you want to change the default kernel command line parameters
+echo you can override the defaults here.
+echo
+echo Currently set to: ${cmdline}
+echo
+echo -n Enter cmdline parameters: ${} && read cmdline
+goto utils_menu
+
 :memtest
 imgfree
 kernel {{ utilitiespcbios.memtest.util_path }}
 boot
-goto utils_exit
+goto utils_menu
 
 :nbxyz-custom
-echo EXPERIMENTAL
-echo 
 echo Make sure you have a fork of https://github.com/netbootxyz/netboot.xyz-custom.
 echo You can then customize your fork as needed and set up your own custom options.
 echo Once your username is set, a custom option will appear on the main menu.
 echo
 echo -n Please enter your Github username: ${} && read github_user
-goto utils_exit 
+goto utils_menu
 
 :testdistro
 echo This option will allow you to test booting an ISO using memdisk. Please
@@ -72,7 +81,7 @@ echo -n URL: ${} && read distro_iso
 kernel ${memdisk} iso raw
 initrd ${distro_iso}
 boot
-goto utils_exit
+goto utils_menu
 
 :utils_exit
 clear menu

--- a/roles/netbootxyz/templates/menu/zeninstall.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/zeninstall.ipxe.j2
@@ -18,7 +18,7 @@ goto zen_boot
 :zen_boot
 imgfree
 set url ${live_endpoint}{{ endpoints.zeninstall.path }}
-kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} initrd=initrd
+kernel ${url}vmlinuz archisobasedir=arch ${ipparam} archiso_http_srv=${url} initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 goto zen_exit


### PR DESCRIPTION
Adds support for adding cmdline options to the
various kernel cmdlines.  Useful for overriding or
adding options as needed when loading the kernels.

Can be set from the Utilities menu.  Variable added to the end
of the kernel command line to ensure that a long entry doesn't
mess up boot from kernel line character limitations and the
entry getting cut off.

Resolves: https://github.com/netbootxyz/netboot.xyz/issues/652