### PR TITLE
Update OpenBSD to 6.7

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -283,8 +283,8 @@ releases:
       image_ver: '63'
       name: '6.3'
     - code_name: snapshots
-      image_ver: '66'
-      name: 6.6 Latest Snapshot
+      image_ver: '67'
+      name: 6.7 Latest Snapshot
   opensuse:
     base_dir: distribution/leap
     enabled: true

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -267,6 +267,9 @@ releases:
     mirror: http://ftp.openbsd.org
     name: OpenBSD
     versions:
+    - code_name: '6.7'
+      image_ver: '67'
+      name: '6.7'
     - code_name: '6.6'
       image_ver: '66'
       name: '6.6'


### PR DESCRIPTION
Updates the list of OpenBSD releases to include 6.7, and updates the "snapshots" information to be current.