### PR TITLE
Updates kernel filename for Arch Linux

### DIFF
--- a/roles/netbootxyz/templates/menu/archlinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/archlinux.ipxe.j2
@@ -33,7 +33,7 @@ goto boot
 imgfree
 set dir ${archlinux_base_dir}/iso/${arch_version}/arch/boot
 set params initrd=archiso.img archiso_http_srv=http://${real_archlinux_mirror}/${archlinux_base_dir}/iso/${arch_version}/ archisobasedir=arch verify=y ${ipparam} net.ifnames=0 ${cmdline}
-kernel http://${archlinux_mirror}/${dir}/x86_64/vmlinuz ${params} initrd=archiso.img
+kernel http://${archlinux_mirror}/${dir}/x86_64/vmlinuz-linux ${params} initrd=archiso.img
 initrd http://${archlinux_mirror}/${dir}/x86_64/archiso.img
 echo
 echo MD5sums:


### PR DESCRIPTION
Upstream renamed vmlinuz to vmlinuz-linux, this
reflects that change.

Fixes https://github.com/netbootxyz/netboot.xyz/issues/695