### PR TITLE
Removes Ubuntu 20.10 groovy net installer

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -511,8 +511,6 @@ releases:
     mirror: http://archive.ubuntu.com
     name: Ubuntu
     versions:
-    - code_name: groovy
-      name: 20.10 Groovy Gorilla
     - code_name: focal
       name: 20.04 LTS Focal Fossa
     - code_name: bionic


### PR DESCRIPTION
As of launch of 20.10, Ubuntu is no longer providing
PXE boot installer images.

You can leverage LiveCDs for installs for now.