### PR TITLE
Adds experimental support for Raspberry Pi 4

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -65,6 +65,7 @@ generate_disks: true
 generate_disks_arm: false
 generate_disks_efi: true
 generate_disks_legacy: true
+generate_disks_rpi: false
 generate_menus: true
 generate_signatures: false
 generate_version_file: true
@@ -78,6 +79,9 @@ memdisk_location: http://${boot_domain}/memdisk
 netbootxyz_conf_dir: /etc/netbootxyz
 netbootxyz_root: /var/www/html
 pciids_url: https://raw.githubusercontent.com/netbootxyz/pciids/master/pciids.ipxe
+pipxe_branch: testing
+pipxe_repo: https://github.com/netbootxyz/pipxe
+pipxe_source_dir: /usr/src/pipxe
 releases:
   alpinelinux:
     base_dir: alpine

--- a/roles/netbootxyz/tasks/generate_disks.yml
+++ b/roles/netbootxyz/tasks/generate_disks.yml
@@ -13,3 +13,7 @@
   - include: generate_disks_arm.yml
     when:
     - generate_disks_arm | default(false) | bool
+
+  - include: generate_disks_rpi.yml
+    when:
+    - generate_disks_rpi | default(false) | bool

--- a/roles/netbootxyz/tasks/generate_disks_rpi.yml
+++ b/roles/netbootxyz/tasks/generate_disks_rpi.yml
@@ -1,0 +1,66 @@
+---
+    - name: Install required packages
+      package:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ pipxe_packages }}"
+
+    - name: Check out latest pipxe sources
+      git:
+        repo: "{{ pipxe_repo }}"
+        dest: "{{ pipxe_source_dir }}"
+        version: "{{ pipxe_branch }}"
+        force: true
+        recursive: yes
+      register: pipxe_git_checkout
+
+    - name: Copy iPXE Bootloader template to iPXE source directory
+      template:
+        src: "disks/{{ bootloader_filename }}.j2"
+        dest: "{{ pipxe_source_dir }}/ipxe/src/{{ bootloader_filename }}"
+
+    - name: Copy netboot.xyz local EFI iPXE configs
+      copy:
+        src: "ipxe/local/{{ item }}"
+        dest: "{{ pipxe_source_dir }}/ipxe/src/config/local/{{ item }}"
+      with_items:
+        - colour.h
+        - console.h
+        - crypto.h
+
+    - name: Copy netboot.xyz general.h.efi iPXE config
+      copy:
+        src: "ipxe/local/general.h.efi"
+        dest: "{{ pipxe_source_dir }}/ipxe/src/config/local/general.h"
+
+    - name: Set trust file to ipxe ca
+      set_fact:
+        trust_files: "{{ cert_dir }}/{{ ipxe_ca_filename }}"
+      when: not generate_signatures
+
+    - name: Combine trust files if set
+      set_fact:
+        trust_files: "{{ cert_dir }}/{{ ipxe_ca_filename }},{{ cert_dir }}/{{ cert_file_filename }}"
+      when: generate_signatures | bool
+
+    - name: Copy Makefile template into pipxe
+      template:
+        src: pipxe/Makefile-rpi4.j2
+        dest: "{{ pipxe_source_dir }}/Makefile"
+
+    - name: Compile iPXE bootloader for RPI build
+      shell: |
+        make
+      args:
+        chdir: "{{ pipxe_source_dir }}"
+      tags:
+      - skip_ansible_lint
+
+    - name: Copy iPXE RPI builds to http directory
+      copy:
+        src: "{{ pipxe_source_dir }}/{{ item.src }}"
+        dest: "{{ netbootxyz_root }}/ipxe/{{ item.dest }}"
+        remote_src: True
+      with_items:
+        - { src: "sdcard.img", dest: "{{ bootloader_filename }}-rpi4.sdcard.img" }
+        - { src: "ipxe/src/bin-arm64-efi/rpi.efi", dest: "{{ bootloader_filename }}-rpi4-snp.efi" }

--- a/roles/netbootxyz/templates/pipxe/Makefile-rpi3.j2
+++ b/roles/netbootxyz/templates/pipxe/Makefile-rpi3.j2
@@ -1,0 +1,77 @@
+FW_URL		:= https://github.com/raspberrypi/firmware/branches/stable/boot
+SHELL		:= /bin/bash
+EFI_BUILD	:= RELEASE
+EFI_ARCH	:= AARCH64
+EFI_TOOLCHAIN	:= GCC5
+EFI_TIMEOUT	:= 3
+EFI_FLAGS	:= --pcd=PcdPlatformBootTimeOut=$(EFI_TIMEOUT)
+EFI_DSC		:= edk2-platforms/Platform/RaspberryPi/RPi3/RPi3.dsc
+EFI_FD		:= Build/RPi3/$(EFI_BUILD)_$(EFI_TOOLCHAIN)/FV/RPI_EFI.fd
+
+IPXE_CROSS	:= aarch64-linux-gnu-
+IPXE_SRC	:= ipxe/src
+IPXE_TGT	:= bin-arm64-efi/rpi.efi
+IPXE_EFI	:= $(IPXE_SRC)/$(IPXE_TGT)
+
+SDCARD_MB	:= 32
+export MTOOLSRC	:= mtoolsrc
+
+all : sdcard sdcard.img sdcard.zip
+
+submodules :
+	git submodule update --init --recursive
+
+firmware :
+	if [ ! -e firmware ] ; then \
+		$(RM) -rf firmware-tmp ; \
+		svn export $(FW_URL) firmware-tmp && \
+		mv firmware-tmp firmware ; \
+	fi
+
+efi : $(EFI_FD)
+
+efi-basetools : submodules
+	$(MAKE) -C edk2/BaseTools
+
+$(EFI_FD) : submodules efi-basetools
+	. ./edksetup.sh && \
+	build -b $(EFI_BUILD) -a $(EFI_ARCH) -t $(EFI_TOOLCHAIN) \
+		-p $(EFI_DSC) $(EFI_FLAGS)
+
+ipxe : $(IPXE_EFI)
+
+$(IPXE_EFI) : submodules
+	$(MAKE) -C $(IPXE_SRC) CROSS=$(IPXE_CROSS) CONFIG=rpi EMBED={{ bootloader_filename }} TRUST={{ trust_files }} $(IPXE_TGT)
+
+sdcard : firmware efi ipxe
+	$(RM) -rf sdcard
+	mkdir -p sdcard
+	cp -r $(sort $(filter-out firmware/kernel%,$(wildcard firmware/*))) \
+		sdcard/
+	cp config.txt $(EFI_FD) edk2/License.txt sdcard/
+	mkdir -p sdcard/efi/boot
+	cp $(IPXE_EFI) sdcard/efi/boot/bootaa64.efi
+	cp ipxe/COPYING* sdcard/
+
+sdcard.img : sdcard
+	truncate -s $(SDCARD_MB)M $@
+	mpartition -I -c -b 32 -s 32 -h 64 -t $(SDCARD_MB) -a "z:"
+	mformat -v "piPXE" "z:"
+	mcopy -s sdcard/* "z:"
+
+sdcard.zip : sdcard
+	$(RM) -f $@
+	( pushd $< ; zip -q -r ../$@ * ; popd )
+
+update:
+	git submodule foreach git pull origin master
+
+tag :
+	git tag v`git show -s --format='%ad' --date=short | tr -d -`
+
+.PHONY : submodules firmware efi efi-basetools $(EFI_FD) ipxe $(IPXE_EFI) \
+	 sdcard sdcard.img
+
+clean :
+	$(RM) -rf firmware Build sdcard sdcard.img sdcard.zip
+	if [ -d $(IPXE_SRC) ] ; then $(MAKE) -C $(IPXE_SRC) clean ; fi

--- a/roles/netbootxyz/templates/pipxe/Makefile-rpi4.j2
+++ b/roles/netbootxyz/templates/pipxe/Makefile-rpi4.j2
@@ -1,0 +1,77 @@
+FW_URL		:= https://github.com/raspberrypi/firmware/branches/stable/boot
+SHELL		:= /bin/bash
+EFI_BUILD	:= RELEASE
+EFI_ARCH	:= AARCH64
+EFI_TOOLCHAIN	:= GCC5
+EFI_TIMEOUT	:= 3
+EFI_FLAGS	:= --pcd=PcdPlatformBootTimeOut=$(EFI_TIMEOUT)
+EFI_DSC		:= edk2-platforms/Platform/RaspberryPi/RPi4/RPi4.dsc
+EFI_FD		:= Build/RPi4/$(EFI_BUILD)_$(EFI_TOOLCHAIN)/FV/RPI_EFI.fd
+
+IPXE_CROSS	:= aarch64-linux-gnu-
+IPXE_SRC	:= ipxe/src
+IPXE_TGT	:= bin-arm64-efi/rpi.efi
+IPXE_EFI	:= $(IPXE_SRC)/$(IPXE_TGT)
+
+SDCARD_MB	:= 32
+export MTOOLSRC	:= mtoolsrc
+
+all : sdcard sdcard.img sdcard.zip
+
+submodules :
+	git submodule update --init --recursive
+
+firmware :
+	if [ ! -e firmware ] ; then \
+		$(RM) -rf firmware-tmp ; \
+		svn export $(FW_URL) firmware-tmp && \
+		mv firmware-tmp firmware ; \
+	fi
+
+efi : $(EFI_FD)
+
+efi-basetools : submodules
+	$(MAKE) -C edk2/BaseTools
+
+$(EFI_FD) : submodules efi-basetools
+	. ./edksetup.sh && \
+	build -b $(EFI_BUILD) -a $(EFI_ARCH) -t $(EFI_TOOLCHAIN) \
+		-p $(EFI_DSC) $(EFI_FLAGS)
+
+ipxe : $(IPXE_EFI)
+
+$(IPXE_EFI) : submodules
+	$(MAKE) -C $(IPXE_SRC) CROSS=$(IPXE_CROSS) CONFIG=rpi EMBED={{ bootloader_filename }} TRUST={{ trust_files }} $(IPXE_TGT)
+
+sdcard : firmware efi ipxe
+	$(RM) -rf sdcard
+	mkdir -p sdcard
+	cp -r $(sort $(filter-out firmware/kernel%,$(wildcard firmware/*))) \
+		sdcard/
+	cp config.txt $(EFI_FD) edk2/License.txt sdcard/
+	mkdir -p sdcard/efi/boot
+	cp $(IPXE_EFI) sdcard/efi/boot/bootaa64.efi
+	cp ipxe/COPYING* sdcard/
+
+sdcard.img : sdcard
+	truncate -s $(SDCARD_MB)M $@
+	mpartition -I -c -b 32 -s 32 -h 64 -t $(SDCARD_MB) -a "z:"
+	mformat -v "piPXE" "z:"
+	mcopy -s sdcard/* "z:"
+
+sdcard.zip : sdcard
+	$(RM) -f $@
+	( pushd $< ; zip -q -r ../$@ * ; popd )
+
+update:
+	git submodule foreach git pull origin master
+
+tag :
+	git tag v`git show -s --format='%ad' --date=short | tr -d -`
+
+.PHONY : submodules firmware efi efi-basetools $(EFI_FD) ipxe $(IPXE_EFI) \
+	 sdcard sdcard.img
+
+clean :
+	$(RM) -rf firmware Build sdcard sdcard.img sdcard.zip
+	if [ -d $(IPXE_SRC) ] ; then $(MAKE) -C $(IPXE_SRC) clean ; fi

--- a/roles/netbootxyz/vars/ubuntu.yml
+++ b/roles/netbootxyz/vars/ubuntu.yml
@@ -11,7 +11,22 @@ netbootxyz_packages:
   - git
   - isolinux
   - liblzma-dev
-  - python3-apt
   - syslinux
   - syslinux-common
   - toilet
+
+pipxe_packages:
+  - acpica-tools
+  - binutils
+  - binutils-dev
+  - gcc
+  - libuuid1
+  - make
+  - mtools
+  - perl
+  - python
+  - subversion
+  - uuid
+  - uuid-dev
+  - virtualenv
+  - xz-utils

--- a/script/netbootxyz-overrides.yml
+++ b/script/netbootxyz-overrides.yml
@@ -2,6 +2,7 @@
 sigs_menu: true
 sigs_enabled: true
 generate_disks_arm: true
+generate_disks_rpi: true
 generate_version_file: true
 bootloader_multiple: true
 bootloader_disks:


### PR DESCRIPTION
Adds experimental support for Raspberry Pi 4 to
the netboot.xyz bootloader.  Leverages the pipxe
project to build images.