### PR TITLE
Remove NixOS 19.09 and make menu more dynamic

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -1314,14 +1314,6 @@ endpoints:
     - netboot.ipxe
     os: nixos
     version: '20.03'
-  nixos-19.09:
-    path: /asset-mirror/releases/download/122708153-fbcf280f/
-    files:
-    - bzImage
-    - initrd
-    - netboot.ipxe
-    os: nixos
-    version: '19.09'
   backbox-7-default-squash:
     path: /ubuntu-squash/releases/download/7-8df8aaac/
     files:

--- a/roles/netbootxyz/templates/menu/nixos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/nixos.ipxe.j2
@@ -6,11 +6,18 @@
 set os {{ releases.nixos.name }}
 menu ${os}
 item --gap Official Releases
-item 20.03 ${space} ${os} 20.03
-item 19.09 ${space} ${os} 19.09
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "nixos" %}
+item {{ value.version }} ${space} ${os} {{ value.version }}
+{% endif %}
+{% endfor %}
 choose version || goto nixos_exit
-iseq ${version} 20.03 && set link ${live_endpoint}{{ endpoints["nixos-20.03"].path }}netboot.ipxe ||
-iseq ${version} 19.09 && set link ${live_endpoint}{{ endpoints["nixos-19.09"].path }}netboot.ipxe ||
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "nixos" %}
+iseq ${version} {{ value.version }} set link ${live_endpoint}{{ value.path }}netboot.ipxe ||
+{% endif %}
+{% endfor %}
 imgfree
 chain ${link}
 goto nixos_exit


### PR DESCRIPTION
19.09 is EOL so this drops it from menu. Makes
changes to the menu to allow it to be more dynamic
with endpoint changes