### PR TITLE
Add initial structure for arm menus

### DIFF
--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -63,8 +63,11 @@ goto architectures_end
 iseq ${platform} efi && goto efi ||
 goto architectures_end
 :arm64
+set menu_linux 0
+set menu_linux_arm 1
 set menu_freedos 0
 set menu_live 0
+set menu_live_arm 1
 set menu_security 0
 set menu_windows 0
 set menu_utils 0

--- a/roles/netbootxyz/templates/menu/linux-arm.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/linux-arm.ipxe.j2
@@ -1,0 +1,35 @@
+#!ipxe
+
+goto ${menu} ||
+
+:linux_menu
+menu Linux Installers - ARM ARCH **EXPERIMENTAL** Current Arch [ ${arch} ]
+item --gap Popular Linux Operating Systems:
+item centos ${space} CentOS
+item debian ${space} Debian
+item fedora ${space} Fedora
+item opensuse ${space} openSUSE
+item ubuntu ${space} Ubuntu
+item --gap All Others:
+#item alpinelinux ${space} Alpine Linux
+#item coreos ${space} Fedora CoreOS (Preview)
+#item flatcar ${space} Flatcar
+#item nixos ${space} NixOS
+item rhel ${space} Red Hat Enterprise Linux
+#item tinycore ${space} Tiny Core Linux
+choose menu || goto linux_exit
+echo ${cls}
+goto ${menu} ||
+iseq ${sigs_enabled} true && goto verify_sigs || goto change_menu
+
+:verify_sigs
+imgverify ${menu}.ipxe ${sigs}${menu}.ipxe.sig || goto error
+goto change_menu
+
+:change_menu
+chain ${menu}.ipxe || goto error
+goto linux_menu
+
+:linux_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -46,7 +46,9 @@ item --gap Default:
 item local ${space} Boot from local hdd
 item --gap Distributions:
 iseq ${menu_linux} 1 && item linux ${space} Linux Network Installs ||
+iseq ${menu_linux_arm} 1 && item linux-arm ${space} Linux Network Installs ||
 iseq ${menu_live} 1 && item live ${space} Live CDs ||
+iseq ${menu_live_arm} 1 && item live-arm ${space} Live CDs ||
 iseq ${menu_bsd} 1 && item bsd ${space} BSD Installs ||
 iseq ${menu_unix} 1 && item unix ${space} Unix Network Installs ||
 iseq ${menu_freedos} 1 && item freedos ${space} FreeDOS || 

--- a/roles/netbootxyz/templates/menu/utils-arm.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-arm.ipxe.j2
@@ -8,7 +8,6 @@ item {{ key }} ${space} {{ value.name }}
 {% endif %}
 {% endfor %}
 item --gap netboot.xyz tools:
-item nbxyz-custom ${space} Set Github username [user: ${github_user}]
 item nbxyz ${space} netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
 echo ${cls}
@@ -26,16 +25,6 @@ boot
 goto utils_exit
 {% endif %}
 {% endfor %}
-
-:nbxyz-custom
-echo EXPERIMENTAL
-echo 
-echo Make sure you have a fork of https://github.com/netbootxyz/netboot.xyz-custom.
-echo You can then customize your fork as needed and set up your own custom options.
-echo Once your username is set, a custom option will appear on the main menu.
-echo
-echo -n Please enter your Github username: ${} && read github_user
-goto utils_exit
 
 :utils_exit
 clear menu


### PR DESCRIPTION
Adds linux, live, and util menus that should be pulled
instead of x86 when arm arch detected.