### PR TITLE
Switch to fedoraproject redirect mirror

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -193,10 +193,10 @@ releases:
       - code_name: chimaera
         name: Chimaera (testing)
   fedora:
-    base_dir: fedora
+    base_dir: pub/fedora
     enabled: true
     menu: linux
-    mirror: http://mirrors.kernel.org
+    mirror: http://download.fedoraproject.org
     name: Fedora
     versions:
     - code_name: '33'


### PR DESCRIPTION
mirrors.kernel.org has been sluggish and unstable lately
so switching to upstream to see how well it works.