### PR TITLE
Only run the generate rpi on one loader

### DIFF
--- a/roles/netbootxyz/tasks/generate_disks.yml
+++ b/roles/netbootxyz/tasks/generate_disks.yml
@@ -17,3 +17,4 @@
   - include: generate_disks_rpi.yml
     when:
     - generate_disks_rpi | default(false) | bool
+    - bootloader_filename == "netboot.xyz"


### PR DESCRIPTION
Limits the rpi loader to be generated on a single
configuration.