### PR TITLE
Fix NixOS ipxe error

### DIFF
--- a/roles/netbootxyz/templates/menu/nixos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/nixos.ipxe.j2
@@ -15,7 +15,7 @@ choose version || goto nixos_exit
 
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "nixos" %}
-iseq ${version} {{ value.version }} set link ${live_endpoint}{{ value.path }}netboot.ipxe ||
+iseq ${version} {{ value.version }} && set link ${live_endpoint}{{ value.path }}netboot.ipxe ||
 {% endif %}
 {% endfor %}
 imgfree


### PR DESCRIPTION
#745 Looks break the NixOS boot
<img width="720" alt="Snipaste_2020-11-17_00-41-27" src="https://user-images.githubusercontent.com/7685264/99281589-a59ce000-286d-11eb-8e75-137d841d8836.png">
