### PR TITLE
Flip to using inst.repo instead of repo

### DIFF
--- a/roles/netbootxyz/templates/menu/centos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/centos.ipxe.j2
@@ -60,7 +60,7 @@ goto boottype
 
 :bootos_images
 imgfree
-kernel ${centos_mirror}/${dir}/images/pxeboot/vmlinuz repo=${repo} ${params} ${ipparam} initrd=initrd.img ${cmdline} 
+kernel ${centos_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${params} ${ipparam} initrd=initrd.img ${cmdline} 
 initrd ${centos_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/fedora.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/fedora.ipxe.j2
@@ -61,7 +61,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${fedora_mirror}/${dir}/images/pxeboot/vmlinuz repo=${fedora_mirror}/${dir} ${params} ${ipparam} initrd=initrd.img ${cmdline}
+kernel ${fedora_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${fedora_mirror}/${dir} ${params} ${ipparam} initrd=initrd.img ${cmdline}
 initrd ${fedora_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/oracle.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/oracle.ipxe.j2
@@ -31,7 +31,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz ${ipparam} repo=${repo} root=live:${url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd ${cmdline}
+kernel ${url}vmlinuz ${ipparam} inst.repo=${repo} root=live:${url}squashfs.img ro rd.live.image rd.lvm=0 rd.luks=0 rd.md=0 rd.dm=0 initrd=initrd ${cmdline}
 initrd ${url}initrd
 boot
 

--- a/roles/netbootxyz/templates/menu/rhel.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rhel.ipxe.j2
@@ -49,7 +49,7 @@ goto boot
 
 :boot
 imgfree
-kernel ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz repo=${rhel_base_url}/os/${rhel_arch} ${ipparam} ${params} initrd=initrd.img ${cmdline}
+kernel ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz inst.repo=${rhel_base_url}/os/${rhel_arch} ${ipparam} ${params} initrd=initrd.img ${cmdline}
 initrd ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/initrd.img
 md5sum vmlinuz initrd.img
 boot


### PR DESCRIPTION
Fedora 33 was tossing messages that repo is deprecated
and is getting removed.  Mentions to use inst.repo instead
so making this change on the other distros that it may
apply to.