### PR TITLE
Remove older versions of Kali and fix menu up

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -336,53 +336,6 @@ endpoints:
     version: rolling
     flavor: xfce
     kernel: kali-xfce-squash
-  kali-light-squash:
-    path: /debian-squash/releases/download/2019.4-544b485d/
-    files:
-    - filesystem.squashfs
-    os: kali
-    version: rolling
-    flavor: light
-    kernel: kali-rolling-live-kernel
-  kali-mate-squash:
-    path: /debian-squash/releases/download/2019.4-0e4d0210/
-    files:
-    - filesystem.squashfs
-    os: kali
-    version: rolling
-    flavor: MATE
-    kernel: kali-rolling-live-kernel
-  kali-rolling-live-kernel:
-    path: /debian-core-10/releases/download/2019.4-e865a2ba/
-    files:
-    - initrd
-    - vmlinuz
-    os: kali
-    version: rolling
-  kali-kde-squash:
-    path: /debian-squash/releases/download/2019.4-d761db15/
-    files:
-    - filesystem.squashfs
-    os: kali
-    version: rolling
-    flavor: KDE
-    kernel: kali-rolling-live-kernel
-  kali-gnome-squash:
-    path: /debian-squash/releases/download/2019.4-734e93c5/
-    files:
-    - filesystem.squashfs
-    os: kali
-    version: rolling
-    flavor: Gnome
-    kernel: kali-rolling-live-kernel
-  kali-lxde-squash:
-    path: /debian-squash/releases/download/2019.4-78e57944/
-    files:
-    - filesystem.squashfs
-    os: kali
-    version: rolling
-    flavor: LXDE
-    kernel: kali-rolling-live-kernel
   tails-4.0-live-kernel:
     path: /debian-core-10/releases/download/5.3.2-1-8095e6f1/
     files:

--- a/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-kali.ipxe.j2
@@ -19,11 +19,6 @@ goto ${live_version}
 item {{ key }} ${space} {{ value.os | title }} {{ value.version | title }} {{ value.flavor | upper }}
 {% endif %}
 {% endfor %}
-{% for key, value in endpoints.items() | sort %}
-{% if value.os == "kali" and 'squash' in key and value.version == "rolling" and value.flavor != "xfce" %}
-item {{ key }} ${space} {{ value.os | title }} 2019.4 {{ value.flavor | upper }}
-{% endif %}
-{% endfor %}
 goto flavor_select
 
 :flavor_select
@@ -32,21 +27,12 @@ echo ${cls}
 goto ${flavor} ||
 
 {% for key, value in endpoints.items() | sort %}
-{% if value.os == "kali" and 'squash' in key and value.flavor != "xfce" %}
-{% set kernel_name = value.kernel %}
+{% if value.os == "kali" and 'squash' in key %}
 :{{ key }}
-set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
-set params components username=root hostname=kali
-{% for key, value in endpoints.items() | sort %}
-{% if key == kernel_name %}
-set kernel_url ${live_endpoint}{{ value.path }}
-{% endif %}
-{% endfor %}
-goto boot
-{% elif value.os == "kali" %}
 set squash_url ${live_endpoint}{{ value.path }}filesystem.squashfs
 set kernel_url ${live_endpoint}{{ value.path }}
 set params components
+goto boot
 {% endif %}
 {% endfor %}
 


### PR DESCRIPTION
Removes older versions of Kali to clean up usage since
all versions are now collapsed into one release.