### PR TITLE
Use interactive_netmount function if no dhcp

### DIFF
--- a/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
@@ -91,8 +91,9 @@ goto sub_boot
 
 :sub_boot
 imgfree
+isset ${dhcp-server} && set netboot_params ip=dhcp url=http://releases.ubuntu.com/${codename}/ubuntu-${version_number}-live-server-${arch_a}.iso || set netboot_params
 echo Loading Ubuntu Subiquity Network Installer...
-kernel ${kernel_url}vmlinuz root=/dev/ram0 ramdisk_size=1500000 ip=dhcp url=http://releases.ubuntu.com/${codename}/ubuntu-${version_number}-live-server-${arch_a}.iso ${install_params} initrd=initrd ${cmdline}
+kernel ${kernel_url}vmlinuz root=/dev/ram0 ramdisk_size=1500000 ${netboot_params} ${install_params} initrd=initrd ${cmdline}
 initrd ${kernel_url}initrd
 echo
 echo MD5sums:


### PR DESCRIPTION
Falls back to new interactive_netmount function in casper
if dhcp server is not found.  Allows for manual network
configuration in scenarios where someone does not have a dhcp
server and needs to install Ubuntu.

Applies to 20.04 and on only.