### PR TITLE
Set a custom url option from utilities

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -72,6 +72,7 @@ checksums_filename: '{{ site_name }}-sha256-checksums.txt'
 codesign_cert_filename: codesign.crt
 codesign_key_filename: codesign.key
 custom_generate_menus: false
+custom_url_menus: true
 custom_github_menus: true
 custom_templates_dir: '{{ netbootxyz_conf_dir }}/custom'
 generate_checksums: true

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -73,6 +73,10 @@ item sig_check ${space} {{ site_name }} [ enabled: ${sigs_enabled} ]
 isset ${github_user} && item --gap Custom Github Menu: ||
 isset ${github_user} && item custom-github ${space} ${github_user}'s Custom Menu ||
 {% endif %}
+{% if custom_url_menus | bool %}
+isset ${custom_url} && item --gap Custom URL Menu: ||
+isset ${custom_url} && item custom-url ${space} Custom URL Menu ||
+{% endif %}
 {% if custom_generate_menus | bool %}
 item --gap Custom User Menus: ||
 item custom-user ${space} Custom User Menus
@@ -120,6 +124,10 @@ goto main_menu
 
 :custom-github
 chain https://raw.githubusercontent.com/${github_user}/netboot.xyz-custom/master/custom.ipxe || goto error
+goto main_menu
+
+:custom-url
+chain ${custom_url}/custom.ipxe || goto error
 goto main_menu
 
 :custom-user

--- a/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-efi.ipxe.j2
@@ -10,7 +10,8 @@ item {{ key }} ${space} {{ value.name }}
 {% endfor %}
 item --gap netboot.xyz tools:
 item cmdline ${space} Kernel cmdline params: [${cmdline}]
-item nbxyz-custom ${space} Set Github username [user: ${github_user}]
+item nbxyz_custom_url ${space} Set custom menu [url: ${custom_url}]
+item nbxyz_custom_github ${space} Set Github username [user: ${github_user}]
 item nbxyz ${space} netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
 echo ${cls}
@@ -38,9 +39,15 @@ echo
 echo -n Enter cmdline parameters: ${} && read cmdline
 goto utils_menu
 
-:nbxyz-custom
-echo EXPERIMENTAL
-echo 
+:nbxyz_custom_url
+echo If you have a customized menu you would like to load into netboot.xyz
+echo set the base path url to your custom ipxe files here. 
+echo It will look for custom.ipxe in that path as the entry point.
+echo
+echo -n Please enter your custom http url here: ${} && read custom_url
+goto utils_menu
+
+:nbxyz_custom_github
 echo Make sure you have a fork of https://github.com/netbootxyz/netboot.xyz-custom.
 echo You can then customize your fork as needed and set up your own custom options.
 echo Once your username is set, a custom option will appear on the main menu.

--- a/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-pcbios.ipxe.j2
@@ -10,7 +10,8 @@ item {{ key }} ${space} {{ value.name }}
 {% endfor %}
 item --gap netboot.xyz tools:
 item cmdline ${space} Kernel cmdline params: [${cmdline}]
-item nbxyz-custom ${space} Set Github username [user: ${github_user}]
+item nbxyz_custom_url ${space} Set custom menu [url: ${custom_url}]
+item nbxyz_custom_github ${space} Set Github username [user: ${github_user}]
 item testdistro ${space} Test Distribution ISO
 item nbxyz ${space} netboot.xyz endpoints
 choose --default ${menu} menu || goto utils_exit
@@ -65,7 +66,15 @@ kernel {{ utilitiespcbios.memtest.util_path }}
 boot
 goto utils_menu
 
-:nbxyz-custom
+:nbxyz_custom_url
+echo If you have a customized menu you would like to load into netboot.xyz
+echo set the base path url to your custom ipxe files here. 
+echo It will look for custom.ipxe in that path as the entry point.
+echo
+echo -n Please enter your custom http url here: ${} && read custom_url
+goto utils_menu
+
+:nbxyz_custom_github
 echo Make sure you have a fork of https://github.com/netbootxyz/netboot.xyz-custom.
 echo You can then customize your fork as needed and set up your own custom options.
 echo Once your username is set, a custom option will appear on the main menu.


### PR DESCRIPTION
Can leverage local-vars or manually set a url via utility menu
to load in a custom.ipxe file from the url of your choice.

Useful for issues pertaining to loading from github or if the user
just wants some other options for loading custom.