### PR TITLE
Hide unix menu in EFI mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ## [2.0.32]
+### Changed
+- Disabled Unix Menu on EFI as SmartOS not working in that mode and was the only option on EFI
 
 ## [2.0.31]
 ### Fixes

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -79,6 +79,7 @@ goto architectures_end
 set menu_bsd 0
 set menu_freedos 0
 set menu_security 0
+set menu_unix 0
 goto architectures_end
 :architectures_end
 goto clouds


### PR DESCRIPTION
SmartOS not working in EFI, since only option
for Unix menu for now, we'll disable it until
we can use it again.

Fixes: https://github.com/netbootxyz/netboot.xyz/issues/835