### PR TITLE
Add Ubuntu 21.04 Hirsute Hippo

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -532,6 +532,8 @@ releases:
     mirror: http://archive.ubuntu.com
     name: Ubuntu
     versions:
+    - code_name: hirsute
+      name: 21.04 Hirsute Hippo
     - code_name: groovy
       name: 20.10 Groovy Gorilla
     - code_name: focal

--- a/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/ubuntu.ipxe.j2
@@ -23,6 +23,7 @@ choose ubuntu_version || goto ubuntu_exit
 iseq ${ubuntu_version} older_release && goto older_release ||
 iseq ${ubuntu_version} focal && set install_type sub ||
 iseq ${ubuntu_version} groovy && set install_type sub ||
+iseq ${ubuntu_version} hirsute && set install_type sub ||
 iseq ${ubuntu_version} focal-legacy && set ubuntu_version focal ||
 iseq ${install_type} sub && goto boot_type ||
 goto mirrorcfg


### PR DESCRIPTION
Add Ubuntu 21.04 Hirsute ahead of April 22nd launch.