### PR TITLE
Use version variable from boot disk

### DIFF
--- a/roles/netbootxyz/templates/menu/about.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/about.ipxe.j2
@@ -16,7 +16,7 @@ set fg_cya ${esc:string}[36m
 set fg_whi ${esc:string}[37m
 
 :netabout
-menu ${fg_cya}${bold}About netboot.xyz (Version: {{ boot_version }})
+menu ${fg_cya}${bold}About netboot.xyz (Version: ${boot_version})
 item exit ${bold}Exit back to main menu...${boldoff}
 item --gap --  --------------------------------------------------------------------------
 item about ${fg_gre}${bold}Self Hosting and Live Booting - November 29, 2019


### PR DESCRIPTION
Switches to reflect the proper version of the running release instead of just displaying rolling version.