### PR TITLE
Switch to using genfsimg for iso/img

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -14,21 +14,13 @@ bootloaders:
   hybrid:
   - desc: Used for CD/DVD, Virtual CDs, DRAC/iLO, VMware, Virtual Box
     ipxe_bin: ipxe.iso
-    output_bin: -hybrid.iso
-    type: ISO
-  - desc: Used for creation of USB Keys
-    ipxe_bin: ipxe.usb
-    output_bin: -hybrid.usb
-    type: USB
-  legacy:
-  - desc: Used for CD/DVD, Virtual CDs, DRAC/iLO, VMware, Virtual Box
-    ipxe_bin: ipxe.iso
     output_bin: .iso
     type: ISO
   - desc: Used for creation of USB Keys
-    ipxe_bin: ipxe.usb
-    output_bin: .usb
-    type: USB
+    ipxe_bin: ipxe.img
+    output_bin: .img
+    type: IMG
+  legacy:
   - desc: Used for booting from GRUB/EXTLINUX
     ipxe_bin: ipxe.lkrn
     output_bin: .lkrn
@@ -55,14 +47,6 @@ bootloaders:
     output_bin: -rpi4-snp.efi
     type: DHCP-snp
   uefi:
-  - desc: EFI BIOS, works in Virtual Box EFI mode
-    ipxe_bin: ipxe-efi.eiso
-    output_bin: -efi.iso
-    type: ISO
-  - desc: Used for creation of USB Keys
-    ipxe_bin: ipxe-efi.usb
-    output_bin: -efi.usb
-    type: USB
   - desc: DHCP EFI boot image file, uses built-in iPXE NIC drivers
     ipxe_bin: ipxe.efi
     output_bin: .efi

--- a/roles/netbootxyz/tasks/generate_disks_efi.yml
+++ b/roles/netbootxyz/tasks/generate_disks_efi.yml
@@ -37,33 +37,6 @@
     tags:
     - skip_ansible_lint
 
-  - name: Generate iPXE EFI ISO Disk
-    shell: |
-      mkdir -p efi_tmp
-      dd if=/dev/zero of=efi_tmp/ipxe.img count=2880
-      mformat -i efi_tmp/ipxe.img -m 0xf8 -f 2880
-      mmd -i efi_tmp/ipxe.img ::efi ::efi/boot
-      mcopy -i efi_tmp/ipxe.img bin-x86_64-efi/ipxe.efi ::efi/boot/bootx64.efi
-      genisoimage -o ipxe-efi.eiso -eltorito-alt-boot -eltorito-boot ipxe.img -no-emul-boot efi_tmp
-    args:
-      chdir: "{{ ipxe_source_dir }}/src"
-      warn: false
-    tags:
-    - skip_ansible_lint
-
-  - name: Generate iPXE EFI USB image
-    shell: |
-      truncate -s 3MiB ipxe-efi.usb
-      mkfs.vfat ipxe-efi.usb
-      mmd -i ipxe-efi.usb "::/efi"
-      mmd -i ipxe-efi.usb "::/efi/boot"
-      mcopy -i ipxe-efi.usb bin-x86_64-efi/ipxe.efi "::/efi/boot/bootx64.efi"
-    args:
-      chdir: "{{ ipxe_source_dir }}/src"
-      warn: false
-    tags:
-    - skip_ansible_lint
-
   - name: Copy iPXE EFI builds to http directory
     copy:
       src: "{{ ipxe_source_dir }}/src/{{ item.src }}"
@@ -73,8 +46,6 @@
       - { src: "bin-x86_64-efi/ipxe.efi", dest: "{{ bootloader_filename }}.efi" }
       - { src: "bin-x86_64-efi/snp.efi", dest: "{{ bootloader_filename }}-snp.efi" }
       - { src: "bin-x86_64-efi/snponly.efi", dest: "{{ bootloader_filename }}-snponly.efi" }
-      - { src: "ipxe-efi.eiso", dest: "{{ bootloader_filename }}-efi.iso" }
-      - { src: "ipxe-efi.usb", dest: "{{ bootloader_filename }}-efi.usb" }
     when: bootloader_filename != "netboot.xyz-packet"
 
   - name: Copy iPXE EFI builds to http directory for packet

--- a/roles/netbootxyz/tasks/generate_disks_hybrid.yml
+++ b/roles/netbootxyz/tasks/generate_disks_hybrid.yml
@@ -2,7 +2,8 @@
 
   - name: Generate hybrid ISO image
     shell: |
-      ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-hybrid.iso \
+      ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.iso \
+        -s {{ bootloader_filename }} \
         {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.efi \
         {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.lkrn
     args:
@@ -12,7 +13,8 @@
 
   - name: Generate hybrid USB image
     shell: |
-      ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-hybrid.usb \
+      ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.img \
+        -s {{ bootloader_filename }} \
         {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.efi \
         {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.lkrn
     args:

--- a/roles/netbootxyz/tasks/generate_disks_legacy.yml
+++ b/roles/netbootxyz/tasks/generate_disks_legacy.yml
@@ -23,7 +23,7 @@
   - name: Compile iPXE bootloader for Legacy BIOS
     shell: |
       make clean
-      make EMBED={{ bootloader_filename }} TRUST={{ trust_files }} bin/ipxe.dsk bin/ipxe.iso bin/ipxe.lkrn bin/ipxe.usb bin/ipxe.kpxe bin/undionly.kpxe
+      make EMBED={{ bootloader_filename }} TRUST={{ trust_files }} bin/ipxe.dsk bin/ipxe.lkrn bin/ipxe.kpxe bin/undionly.kpxe
     args:
       chdir: "{{ ipxe_source_dir }}/src"
     tags:
@@ -36,9 +36,7 @@
       remote_src: True
     with_items:
     - ".dsk"
-    - ".iso"
     - ".lkrn"
-    - ".usb"
     - ".kpxe"
     when: bootloader_filename != "netboot.xyz-packet"
 


### PR DESCRIPTION
Renames .usb to .img, combines legacy and efi into
single image, leverages autoexec.ipxe functionality
so that configuration can be altered on usb key to
set variables, debugging or other features directly
on the usb key without having to recompile.