### PR TITLE
adding redorescue to utils menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Fedora 34 and Live Versions
 - Rescuezilla
+- Redo Rescue
 
 ### Changed
 - Switched to using upstream genfsimg for building hybrid images

--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 | Grml | http://grml.org | LiveCD |
 | Kaspersky Rescue Disk | https://support.kaspersky.com/viruses/krd18 | LiveCD |
 | Memtest | http://www.memtest.org/ | Kernel |
+| Redo Rescue | http://redorescue.com/ | LiveCD |
 | Rescatux | https://www.supergrubdisk.org/rescatux/ | LiveCD |
 | Rescuezilla | https://rescuezilla.com/ | LiveCD |
 | ShredOS | https://github.com/PartialVolume/shredos.x86_64 | Kernel | 

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -590,6 +590,14 @@ utilitiesefi:
     enabled: true
     name: Kaspersky Rescue Disk
     type: ipxemenu
+  redorescue:
+    enabled: true
+    initrd: ${live_endpoint}{{ endpoints.redorescue.path }}initrd
+    kernel: ${live_endpoint}{{ endpoints.redorescue.path }}vmlinuz boot=live noprompt nocomponents 
+      setkmap=us fetch=${live_endpoint}{{ endpoints.redorescue.path }}filesystem.squashfs
+      initrd=initrd
+    name: RedoRescue
+    type: direct
   rescatux:
     enabled: true
     initrd: ${live_endpoint}{{ endpoints.rescatux.path }}initrd
@@ -670,6 +678,14 @@ utilitiespcbios:
     type: memtest
     util_path: https://boot.netboot.xyz/utils/memtest86-5.01.0
     version: 5.01.0
+  redorescue:
+    enabled: true
+    initrd: ${live_endpoint}{{ endpoints.redorescue.path }}initrd
+    kernel: ${live_endpoint}{{ endpoints.redorescue.path }}vmlinuz boot=live noprompt nocomponents 
+      setkmap=us fetch=${live_endpoint}{{ endpoints.redorescue.path }}filesystem.squashfs
+      initrd=initrd
+    name: RedoRescue
+    type: direct
   rescatux:
     enabled: true
     initrd: ${live_endpoint}{{ endpoints.rescatux.path }}initrd


### PR DESCRIPTION
Pretty simple Debian buster based one, loop tested the live asset endpoint: 
```
:CUSTOM
imgfree
kernel https://github.com/netbootxyz/asset-mirror/releases/download/3.0.2-cc0d71c0/vmlinuz boot=live noprompt nocomponents setkmap=us fetch=https://github.com/netbootxyz/asset-mirror/releases/download/3.0.2-cc0d71c0/filesystem.squashfs initrd=initrd ${cmdline}
initrd https://github.com/netbootxyz/asset-mirror/releases/download/3.0.2-cc0d71c0/initrd
boot
```