### PR TITLE
Revert "Switch to fedoraproject redirect mirror"

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -195,10 +195,10 @@ releases:
       - code_name: chimaera
         name: Chimaera (testing)
   fedora:
-    base_dir: pub/fedora/linux
+    base_dir: fedora
     enabled: true
     menu: linux
-    mirror: http://download.fedoraproject.org
+    mirror: http://mirrors.kernel.org
     name: Fedora
     versions:
     - code_name: 34


### PR DESCRIPTION
Moves back to original mirror, fedora projects redirect
seems to cause failures on boot and when pulling active repo.

Moving back to something more reliable, will revisit in future.

This reverts commit c3f3cf591cb17808fc6a4c83a49629ce2c52922a.