### PR TITLE
Use remote IPXE for nixos

### DIFF
--- a/roles/netbootxyz/templates/menu/nixos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/nixos.ipxe.j2
@@ -6,20 +6,13 @@
 set os {{ releases.nixos.name }}
 menu ${os}
 item --gap Official Releases
-{% for key, value in endpoints.items() | sort %}
-{% if value.os == "nixos" %}
-item {{ value.version }} ${space} ${os} {{ value.version }}
-{% endif %}
+{% for item in releases.nixos.versions %}
+item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
 choose version || goto nixos_exit
 
-{% for key, value in endpoints.items() | sort %}
-{% if value.os == "nixos" %}
-iseq ${version} {{ value.version }} && set link ${live_endpoint}{{ value.path }}netboot.ipxe ||
-{% endif %}
-{% endfor %}
 imgfree
-chain ${link}
+chain https://github.com/nix-community/nixos-images/releases/download/${version}/netboot-x86_64-linux.ipxe
 goto nixos_exit
 
 :nixos_exit


### PR DESCRIPTION
For right now this is semi broken as the only IPXE file they have updated to point to github assets on their side is unstable, but we should still merge this as they can fix it.
It looks like they are going to constantly roll tags and update the assets in them so the logic pulls an array of all their current tags in this release repo and lists them in the menu for ingestion.