### PR TITLE
Switch Gentoo to leverage initrd.magic functionality

### DIFF
--- a/roles/netbootxyz/templates/menu/gentoo.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/gentoo.ipxe.j2
@@ -7,8 +7,6 @@
 set os {{ releases.gentoo.name }}
 menu ${os} - Current Arch [ ${arch} ]
 iseq ${arch} x86_64 && set arch_a amd64 || set arch_a ${arch}
-item --gap Currently during boot you need to press ctrl+d/ctrl+c
-item --gap repeatedly when init hangs on starting a download
 item --gap ${os} Versions
 {% for key, value in endpoints.items() | sort %}
 {% if value.os == "gentoo" %}
@@ -29,8 +27,9 @@ goto boot
 
 :boot
 imgfree
-kernel ${url}vmlinuz ip=dhcp root=/dev/ram0 init=/linuxrc loop=/image.squashfs looptype=squashfs cdroot=1 real_root=/ fetch=${url}image.squashfs {{ kernel_params }}
+kernel ${url}vmlinuz ip=dhcp root=/dev/ram0 init=/linuxrc loop=/image.squashfs looptype=squashfs cdroot=1 {{ kernel_params }}
 initrd ${url}initrd
+initrd ${url}image.squashfs /image.squashfs
 boot
 
 :gentoo_exit


### PR DESCRIPTION
Switch gentoo to leverage initrd.magic functionality where we can inject the squashfs in.  Also will switch hosted assets to remove init modifications.