### PR TITLE
Change ArchLinux mirror back to Rackspace

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -126,7 +126,7 @@ releases:
     base_dir: archlinux
     enabled: true
     menu: linux
-    mirror: mirrors.evowise.com
+    mirror: mirror.rackspace.com
     name: Arch Linux
     versions:
     - code_name: 2021.07.01


### PR DESCRIPTION
It appears that the evowise.com mirror is kaput, every request gets 302'd to
another website. According to https://archlinux.org/mirrors/evowise.com/893/
this broke around 22 July, 2021 and ArchLinux have pulled the mirror from their
rotation already.

This reverts commit 65ea52a3412ba3aa5ae3c7d6076ab6646307fb5a.