### PR TITLE
Generate local-vars.ipxe by default with examples

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -75,6 +75,7 @@ generate_disks_efi: true
 generate_disks_hybrid: false
 generate_disks_legacy: true
 generate_disks_rpi: false
+generate_local_vars: true
 generate_menus: true
 generate_signatures: false
 generate_version_file: true

--- a/roles/netbootxyz/tasks/generate_menus.yml
+++ b/roles/netbootxyz/tasks/generate_menus.yml
@@ -58,6 +58,13 @@
     tags:
     - skip_ansible_lint
 
+  - name: Generate local-vars.ipxe if enabled
+    template:
+      src: "local-vars.ipxe.j2"
+      dest: "{{ netbootxyz_root }}/local-vars.ipxe"
+    when:
+      - generate_local_vars | bool
+
   - name: Retrieve pciids.ipxe
     get_url:
       url: "{{ pciids_url }}"

--- a/roles/netbootxyz/templates/local-vars.ipxe.j2
+++ b/roles/netbootxyz/templates/local-vars.ipxe.j2
@@ -1,0 +1,5 @@
+#!ipxe
+### used for adding local variables before loading the menu
+
+### set to enable enable github custom menu
+#set github_user my_github_username

--- a/script/netbootxyz-overrides.yml
+++ b/script/netbootxyz-overrides.yml
@@ -5,6 +5,7 @@ generate_disks_arm: true
 generate_disks_hybrid: true
 generate_disks_rpi: true
 generate_version_file: true
+generate_local_vars: false
 bootloader_multiple: true
 bootloader_disks:
   - "netboot.xyz"

--- a/user_overrides.yml
+++ b/user_overrides.yml
@@ -4,6 +4,7 @@
 generate_menus: true
 generate_disks: true
 generate_checksums: true
+generate_local_vars: true
 
 # set desired site name
 #site_name: mysitename.com


### PR DESCRIPTION
Adds the local-vars.ipxe file which can be updated
for changes.  Local vars is parsed on bootup if
the next-server and filename are both set on the
local dhcp server.