### PR TITLE
Some ARM64 fixes

### DIFF
--- a/roles/netbootxyz/templates/menu/centos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/centos.ipxe.j2
@@ -10,21 +10,23 @@ goto ${menu} ||
 
 :centos
 clear osversion
+set rh_arch ${arch}
+iseq ${rh_arch} arm64 && set rh_arch aarch64
 set os {{ releases.centos.name }}
-menu ${os} - ${arch}
+menu ${os} - ${rh_arch}
 {% for item in releases.centos.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
 isset ${osversion} || choose osversion || goto linux_menu
 echo ${cls}
-set dir ${centos_base_dir}/${osversion}/BaseOS/${arch}/os
-iseq ${osversion} 7 && set dir ${centos_base_dir}/${osversion}/os/${arch} ||
+set dir ${centos_base_dir}/${osversion}/BaseOS/${rh_arch}/os
+iseq ${osversion} 7 && set dir ${centos_base_dir}/${osversion}/os/${rh_arch} ||
 set repo ${centos_mirror}/${dir}
 goto boottype
 
 :boottype
 set ova ${os} ${osversion}
-menu ${os} ${arch} boot type
+menu ${os} ${rh_arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue

--- a/roles/netbootxyz/templates/menu/fedora.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/fedora.ipxe.j2
@@ -12,31 +12,33 @@ goto ${menu} ||
 clear osversion
 clear sku_type
 clear ova
+set rh_arch ${arch}
+iseq ${arch} arm64 && set rh_arch aarch64
 set os {{ releases.fedora.name }}
-menu ${os} - ${arch}
+menu ${os} - ${rh_arch}
 item --gap Latest Releases
 {% for item in releases.fedora.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
-iseq ${arch} x86_64 && item rawhide ${space} ${os} rawhide ||
+iseq ${rh_arch} x86_64 && item rawhide ${space} ${os} rawhide ||
 isset ${osversion} || choose osversion || goto linux_menu
 set ova ${os} ${osversion}
 goto product_sku
 
 :product_sku
-menu ${os} ${arch} sku type
+menu ${os} ${rh_arch} sku type
 item Everything ${ova} Everything
 item Server ${ova} Server
-iseq ${arch} x86_64 && item Silverblue ${ova} Silverblue ||
+iseq ${rh_arch} x86_64 && item Silverblue ${ova} Silverblue ||
 isset ${sku_type} || choose sku_type || goto fedora
-set dir ${fedora_base_dir}/releases/${osversion}/${sku_type}/${arch}/os
-iseq ${osversion} rawhide && set dir ${fedora_base_dir}/development/${osversion}/${sku_type}/${arch}/os ||
+set dir ${fedora_base_dir}/releases/${osversion}/${sku_type}/${rh_arch}/os
+iseq ${osversion} rawhide && set dir ${fedora_base_dir}/development/${osversion}/${sku_type}/${rh_arch}/os ||
 set ova ${ova} ${sku_type}
 echo ${cls}
 goto boottype
 
 :boottype
-menu ${os} ${arch} boot type
+menu ${os} ${rh_arch} boot type
 item normal ${ova} graphical install
 item text ${ova} text install
 item rescue ${ova} rescue

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -54,7 +54,7 @@ iseq ${menu_live} 1 && item live ${space} Live CDs ||
 iseq ${menu_live_arm} 1 && item live-arm ${space} Live CDs ||
 iseq ${menu_bsd} 1 && item bsd ${space} BSD Installs ||
 iseq ${menu_unix} 1 && item unix ${space} Unix Network Installs ||
-iseq ${menu_freedos} 1 && item freedos ${space} FreeDOS || 
+iseq ${menu_freedos} 1 && item freedos ${space} FreeDOS ||
 iseq ${menu_windows} 1 && item windows ${space} Windows ||
 item --gap Tools:
 iseq ${menu_utils} 1 && item utils-${platform} ${space} Utilities ||
@@ -114,7 +114,8 @@ shell
 goto main_menu
 
 :changebits
-iseq ${arch} x86_64 && set arch i386 || set arch x86_64
+iseq ${arch} x86_64 && set arch i386 ||
+iseq ${arch} i386 && set arch x86_64 ||
 goto main_menu
 
 :sig_check
@@ -122,7 +123,7 @@ iseq ${sigs_enabled} true && set sigs_enabled false || set sigs_enabled true
 goto main_menu
 
 :about
-chain https://boot.netboot.xyz/about.ipxe || chain about.ipxe 
+chain https://boot.netboot.xyz/about.ipxe || chain about.ipxe
 goto main_menu
 
 :custom-github


### PR DESCRIPTION
1. Correct the `${arch}` parameter for Fedora and CentOS, as they are called `aarch64` in the URLs.
2. Only allow `changebits` between `x86_64` and `i386` and ignore other values, to prevent problems on non-x86 architectures.

Tested on an ARM64 VM.