### PR TITLE
Architecture type refactor to enable arm64 and i386 builds

### DIFF
--- a/roles/netbootxyz/templates/menu/almalinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/almalinux.ipxe.j2
@@ -11,19 +11,22 @@ goto ${menu} ||
 :almalinux
 clear osversion
 set os {{ releases.almalinux.name }}
-menu ${os} - ${arch}
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch x86_64 ||
+iseq ${os_arch} arm64 && set os_arch aarch64 ||
+menu ${os} - ${os_arch}
 {% for item in releases.almalinux.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
 isset ${osversion} || choose osversion || goto linux_menu
 echo ${cls}
-set dir ${almalinux_base_dir}/${osversion}/BaseOS/${arch}/os
+set dir ${almalinux_base_dir}/${osversion}/BaseOS/${os_arch}/os
 set repo ${almalinux_mirror}/${dir}
 goto boottype
 
 :boottype
 set ova ${os} ${osversion}
-menu ${os} ${arch} boot type
+menu ${os} ${os_arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue

--- a/roles/netbootxyz/templates/menu/alpinelinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/alpinelinux.ipxe.j2
@@ -10,8 +10,11 @@ goto ${menu}
 :alpinelinux
 clear alpine_version
 set os {{ releases.alpinelinux.name }}
-iseq ${arch} x86_64 && set bootarch x86_64 || set bootarch x86
-menu ${os} [${bootarch}]
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch x86_64 ||
+iseq ${os_arch} i386 && set os_arch x86 ||
+iseq ${os_arch} arm64 && set os_arch aarch64 ||
+menu ${os} - ${os_arch}
 item --gap Releases
 {% for item in releases.alpinelinux.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
@@ -21,7 +24,7 @@ goto boot
 
 :boot
 set base-url ${alpinelinux_mirror}
-set dir ${alpinelinux_base_dir}/${alpine_version}/releases/${bootarch}/netboot
+set dir ${alpinelinux_base_dir}/${alpine_version}/releases/${os_arch}/netboot
 set repo-url ${alpinelinux_mirror}/${alpinelinux_base_dir}/${alpine_version}/main
 imgfree
 kernel ${base-url}/${dir}/vmlinuz-lts ${ipparam} alpine_repo=${repo-url} modules=loop,squashfs modloop=${base-url}/${dir}/modloop-lts quiet nomodeset {{ kernel_params }}

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -62,6 +62,17 @@ goto architectures_end
 :x86_64
 iseq ${platform} efi && goto efi ||
 goto architectures_end
+:i386
+set menu_linux 0
+set menu_linux_i386 1
+set menu_bsd 1
+set menu_unix 0
+set menu_freedos 1
+set menu_live 0
+set menu_windows 0
+set menu_utils 1
+iseq ${platform} efi && goto efi ||
+goto architectures_end
 :arm64
 set menu_linux 0
 set menu_linux_arm 1

--- a/roles/netbootxyz/templates/menu/centos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/centos.ipxe.j2
@@ -11,20 +11,23 @@ goto ${menu} ||
 :centos
 clear osversion
 set os {{ releases.centos.name }}
-menu ${os} - ${arch}
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch x86_64 ||
+iseq ${os_arch} arm64 && set os_arch aarch64 ||
+menu ${os} - ${os_arch}
 {% for item in releases.centos.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
 isset ${osversion} || choose osversion || goto linux_menu
 echo ${cls}
-set dir ${centos_base_dir}/${osversion}/BaseOS/${arch}/os
-iseq ${osversion} 7 && set dir ${centos_base_dir}/${osversion}/os/${arch} ||
+set dir ${centos_base_dir}/${osversion}/BaseOS/${os_arch}/os
+iseq ${osversion} 7 && set dir ${centos_base_dir}/${osversion}/os/${os_arch} ||
 set repo ${centos_mirror}/${dir}
 goto boottype
 
 :boottype
 set ova ${os} ${osversion}
-menu ${os} ${arch} boot type
+menu ${os} ${os_arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue

--- a/roles/netbootxyz/templates/menu/debian.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/debian.ipxe.j2
@@ -7,9 +7,13 @@ goto ${menu}
 
 :debian
 set os Debian
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch amd64 ||
+iseq ${os_arch} i386 && set os_arch i386 ||
+iseq ${os_arch} arm64 && set os_arch arm64 ||
 clear debian_version
 clear older_release
-menu ${os} - ${arch_a}
+menu ${os} - ${os_arch}
 item --gap Latest Releases
 {% for item in releases.debian.versions.stable %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
@@ -30,13 +34,13 @@ set debian_mirror {{ releases.debian.archive_mirror }}
 echo Setting mirror to ${debian_mirror}
 clear debian_version
 echo -n Please set enter code name of release: ${} && read debian_version
-set dir ${debian_base_dir}/dists/${debian_version}/main/installer-${arch_a}/current/images/netboot/
+set dir ${debian_base_dir}/dists/${debian_version}/main/installer-${os_arch}/current/images/netboot/
 goto deb_boot_type
 
 :mirrorcfg
 set debian_mirror ${debian_mirror}
 set mirrorcfg mirror/suite=${debian_version}
-set dir ${debian_base_dir}/dists/${debian_version}/main/installer-${arch_a}/current/images/netboot/
+set dir ${debian_base_dir}/dists/${debian_version}/main/installer-${os_arch}/current/images/netboot/
 goto deb_boot_type
 
 :deb_boot_type
@@ -66,11 +70,11 @@ set install_params auto=true priority=critical preseed/url=${preseedurl}
 goto deb_text
 
 :deb_text
-set dir ${dir}${menu}-installer/${arch_a}
+set dir ${dir}${menu}-installer/${os_arch}
 goto deb_boot
 
 :deb_graphical
-set dir ${dir}gtk/${menu}-installer/${arch_a}
+set dir ${dir}gtk/${menu}-installer/${os_arch}
 set install_params vga=788
 goto deb_boot
 

--- a/roles/netbootxyz/templates/menu/fedora.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/fedora.ipxe.j2
@@ -13,30 +13,34 @@ clear osversion
 clear sku_type
 clear ova
 set os {{ releases.fedora.name }}
-menu ${os} - ${arch}
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch x86_64 ||
+iseq ${os_arch} arm64 && set os_arch aarch64 ||
+
+menu ${os} - ${os_arch}
 item --gap Latest Releases
 {% for item in releases.fedora.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
-iseq ${arch} x86_64 && item rawhide ${space} ${os} rawhide ||
+iseq ${os_arch} x86_64 && item rawhide ${space} ${os} rawhide ||
 isset ${osversion} || choose osversion || goto linux_menu
 set ova ${os} ${osversion}
 goto product_sku
 
 :product_sku
-menu ${os} ${arch} sku type
+menu ${os} ${os_arch} sku type
 item Everything ${ova} Everything
 item Server ${ova} Server
-iseq ${arch} x86_64 && item Silverblue ${ova} Silverblue ||
+iseq ${os_arch} x86_64 && item Silverblue ${ova} Silverblue ||
 isset ${sku_type} || choose sku_type || goto fedora
-set dir ${fedora_base_dir}/releases/${osversion}/${sku_type}/${arch}/os
-iseq ${osversion} rawhide && set dir ${fedora_base_dir}/development/${osversion}/${sku_type}/${arch}/os ||
+set dir ${fedora_base_dir}/releases/${osversion}/${sku_type}/${os_arch}/os
+iseq ${osversion} rawhide && set dir ${fedora_base_dir}/development/${osversion}/${sku_type}/${os_arch}/os ||
 set ova ${ova} ${sku_type}
 echo ${cls}
 goto boottype
 
 :boottype
-menu ${os} ${arch} boot type
+menu ${os} ${os_arch} boot type
 item normal ${ova} graphical install
 item text ${ova} text install
 item rescue ${ova} rescue

--- a/roles/netbootxyz/templates/menu/linux-arm.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/linux-arm.ipxe.j2
@@ -5,18 +5,20 @@ goto ${menu} ||
 :linux_menu
 menu Linux Installers - ARM ARCH **EXPERIMENTAL** Current Arch [ ${arch} ]
 item --gap Popular Linux Operating Systems:
+item alpinelinux ${space} AlmaLinux
+item alpinelinux ${space} Alpine Linux
 item centos ${space} CentOS
 item debian ${space} Debian
 item fedora ${space} Fedora
-item opensuse ${space} openSUSE
-item ubuntu ${space} Ubuntu
-item --gap All Others:
-#item alpinelinux ${space} Alpine Linux
+item rhel ${space} Red Hat Enterprise Linux
+item rockylinux ${space} Rocky Linux
+#item --gap All Others:
 #item coreos ${space} Fedora CoreOS (Preview)
 #item flatcar ${space} Flatcar
 #item nixos ${space} NixOS
 item rhel ${space} Red Hat Enterprise Linux
 #item tinycore ${space} Tiny Core Linux
+#item ubuntu ${space} Ubuntu
 choose menu || goto linux_exit
 echo ${cls}
 goto ${menu} ||

--- a/roles/netbootxyz/templates/menu/linux-i386.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/linux-i386.ipxe.j2
@@ -1,0 +1,25 @@
+#!ipxe
+
+goto ${menu} ||
+
+:linux_menu
+menu Linux Installers - Current Arch [ ${arch} ]
+item --gap Popular Linux Operating Systems:
+item alpinelinux ${space} Alpine Linux
+item debian ${space} Debian
+choose menu || goto linux_exit
+echo ${cls}
+goto ${menu} ||
+iseq ${sigs_enabled} true && goto verify_sigs || goto change_menu
+
+:verify_sigs
+imgverify ${menu}.ipxe ${sigs}${menu}.ipxe.sig || goto error
+goto change_menu
+
+:change_menu
+chain ${menu}.ipxe || goto error
+goto linux_menu
+
+:linux_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -49,19 +49,18 @@ item --gap Default:
 item local ${space} Boot from local hdd
 item --gap Distributions:
 iseq ${menu_linux} 1 && item linux ${space} Linux Network Installs ||
+iseq ${menu_linux_i386} 1 && item linux-i386 ${space} Linux Network Installs ||
 iseq ${menu_linux_arm} 1 && item linux-arm ${space} Linux Network Installs ||
 iseq ${menu_live} 1 && item live ${space} Live CDs ||
 iseq ${menu_live_arm} 1 && item live-arm ${space} Live CDs ||
 iseq ${menu_bsd} 1 && item bsd ${space} BSD Installs ||
 iseq ${menu_unix} 1 && item unix ${space} Unix Network Installs ||
-iseq ${menu_freedos} 1 && item freedos ${space} FreeDOS || 
+iseq ${menu_freedos} 1 && item freedos ${space} FreeDOS ||
 iseq ${menu_windows} 1 && item windows ${space} Windows ||
 item --gap Tools:
 iseq ${menu_utils} 1 && item utils-${platform} ${space} Utilities ||
 iseq ${menu_utils_arm} 1 && item utils-arm ${space} Utilities ||
-iseq ${arch} x86_64 && set bits 64 || set bits 32
-iseq ${arch} arm64 && set bits 64 ||
-item changebits ${space} Architecture: ${arch} (${bits}bit)
+item change_arch ${space} Architecture: ${arch}
 item shell ${space} iPXE shell
 item netinfo ${space} Network card info
 item lspci ${space} PCI Device List
@@ -113,8 +112,9 @@ set menu main_menu
 shell
 goto main_menu
 
-:changebits
-iseq ${arch} x86_64 && set arch i386 || set arch x86_64
+:change_arch
+iseq ${arch} x86_64 && set arch i386 ||
+iseq ${arch} i386 && set arch x86_64 ||
 goto main_menu
 
 :sig_check
@@ -122,7 +122,7 @@ iseq ${sigs_enabled} true && set sigs_enabled false || set sigs_enabled true
 goto main_menu
 
 :about
-chain https://boot.netboot.xyz/about.ipxe || chain about.ipxe 
+chain https://boot.netboot.xyz/about.ipxe || chain about.ipxe
 goto main_menu
 
 :custom-github

--- a/roles/netbootxyz/templates/menu/rhel.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rhel.ipxe.j2
@@ -6,25 +6,22 @@
 isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}:::none nameserver=${dns}
 set ipparam BOOTIF=${netX/mac} ${ipparam}
 
-set rhel_arch x86_64
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch x86_64 ||
+iseq ${os_arch} arm64 && set os_arch aarch64 ||
 goto ${menu} ||
 
 :rhel
-set os Red Hat Enterprise Linux
+set os Red Hat Enterprise Linux - ${os_arch}
 clear rhel_version
 menu ${os}
 item --gap Installers
 item rhel_install ${space} ${os} Graphical Install
 item rhel_install_text ${space} ${os} Text Install
 item --gap Options:
-item arch_set ${space} Architecture [ ${rhel_arch} ]
 item url_set ${space} Base URL [ ${rhel_base_url} ]
 choose rhel_version || goto rhel_exit
 goto ${rhel_version}
-
-:arch_set
-iseq ${rhel_arch} x86_64 && set rhel_arch i386 || set rhel_arch x86_64
-goto rhel
 
 :url_set
 echo Set the HTTP URL of an extracted RHEL ISO without the trailing slash:
@@ -33,8 +30,8 @@ echo
 echo -n URL: ${} && read rhel_base_url
 echo
 echo netboot.xyz will attempt to load the following files:
-echo ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz
-echo ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/initrd.img
+echo ${rhel_base_url}/os/${os_arch}/images/pxeboot/vmlinuz
+echo ${rhel_base_url}/os/${os_arch}/images/pxeboot/initrd.img
 echo
 prompt Press any key to return to RHEL Menu...
 goto rhel
@@ -49,8 +46,8 @@ goto boot
 
 :boot
 imgfree
-kernel ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/vmlinuz inst.repo=${rhel_base_url}/os/${rhel_arch} ${ipparam} ${params} {{ kernel_params }}
-initrd ${rhel_base_url}/os/${rhel_arch}/images/pxeboot/initrd.img
+kernel ${rhel_base_url}/os/${os_arch}/images/pxeboot/vmlinuz inst.repo=${rhel_base_url}/os/${os_arch} ${ipparam} ${params} {{ kernel_params }}
+initrd ${rhel_base_url}/os/${os_arch}/images/pxeboot/initrd.img
 md5sum vmlinuz initrd.img
 boot
 goto rhel

--- a/roles/netbootxyz/templates/menu/rockylinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rockylinux.ipxe.j2
@@ -11,19 +11,22 @@ goto ${menu} ||
 :rockylinux
 clear osversion
 set os {{ releases.rockylinux.name }}
-menu ${os} - ${arch}
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch x86_64 ||
+iseq ${os_arch} arm64 && set os_arch aarch64 ||
+menu ${os} - ${os_arch}
 {% for item in releases.rockylinux.versions %}
 item {{ item.code_name }} ${space} ${os} {{ item.name }}
 {% endfor %}
 isset ${osversion} || choose osversion || goto linux_menu
 echo ${cls}
-set dir ${rockylinux_base_dir}/${osversion}/BaseOS/${arch}/os
+set dir ${rockylinux_base_dir}/${osversion}/BaseOS/${os_arch}/os
 set repo ${rockylinux_mirror}/${dir}
 goto boottype
 
 :boottype
 set ova ${os} ${osversion}
-menu ${os} ${arch} boot type
+menu ${os} ${os_arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue


### PR DESCRIPTION
For those operating systems that support arm64 (and i386), this
is a start of a refactor to enable operating systems that have
those capabilities.

This is a work in progress and consists of some overdue cleanup.