### PR TITLE
Switch to arch variable instead of buildarch

### DIFF
--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -55,9 +55,9 @@ set menu_freedos 1
 set menu_live 1
 set menu_windows 1
 set menu_utils 1
-iseq ${buildarch} i386 && goto i386 ||
-iseq ${buildarch} x86_64 && goto x86_64 ||
-iseq ${buildarch} arm64 && goto arm64 ||
+iseq ${arch} i386 && goto i386 ||
+iseq ${arch} x86_64 && goto x86_64 ||
+iseq ${arch} arm64 && goto arm64 ||
 goto architectures_end
 :x86_64
 iseq ${platform} efi && goto efi ||
@@ -106,9 +106,9 @@ set cmdline console=ttyS0,115200n8
 goto clouds_end
 
 :packet
-iseq ${buildarch} i386 && goto packet_x86_64 ||
-iseq ${buildarch} x86_64 && goto packet_x86_64 ||
-iseq ${buildarch} arm64 && goto packet_arm64 ||
+iseq ${arch} i386 && goto packet_x86_64 ||
+iseq ${arch} x86_64 && goto packet_x86_64 ||
+iseq ${arch} arm64 && goto packet_arm64 ||
 goto clouds_end
 
 :packet_x86_64

--- a/roles/netbootxyz/templates/menu/menu.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/menu.ipxe.j2
@@ -4,6 +4,10 @@
 {%- endif %}
 
 :start
+isset ${arch} && goto skip_arch_detect ||
+cpuid --ext 29 && set arch x86_64 || set arch i386
+iseq ${buildarch} arm64 && set arch arm64 ||
+:skip_arch_detect
 chain --autofree boot.cfg ||
 echo Attempting to retrieve latest upstream version number...
 chain --timeout 5000 https://boot.netboot.xyz/version.ipxe ||
@@ -31,12 +35,7 @@ chain --autofree http://${boot_domain}/ipxe/${ipxe_disk} ||
 :version_up2date
 {% endif %}
 
-isset ${arch} && goto skip_arch_detect ||
-cpuid --ext 29 && set arch x86_64 || set arch i386
-iseq ${buildarch} arm64 && set arch arm64 ||
-:skip_arch_detect
 isset ${menu} && goto ${menu} ||
-
 isset ${ip} || dhcp
 
 :main_menu


### PR DESCRIPTION
Per iPXE docs, buildarch can be unreliable for architecture
detection, so move our other check earlier and rely
on that for boot.cfg routing.

Have seen issues where tftp booting the image picked up
a 64-bit machine as a 32-bit machine on the bootarch
check and then identifying it with cpuid as a 64-bit machine.

This caused menus to be obscured initially for those machine
types.