### PR TITLE
Enable ability to generate debug iPXE images

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -82,6 +82,8 @@ generate_menus: true
 generate_signatures: false
 generate_version_file: true
 ipxe_branch: master
+ipxe_debug_enabled: false
+ipxe_debug_options: httpcore,tls
 ipxe_ca_filename: ca-ipxe-org.crt
 ipxe_ca_url: http://ca.ipxe.org/ca.crt
 ipxe_repo: https://github.com/ipxe/ipxe

--- a/roles/netbootxyz/tasks/generate_disks_arm.yml
+++ b/roles/netbootxyz/tasks/generate_disks_arm.yml
@@ -37,14 +37,31 @@
     - name: Compile iPXE bootloader for EFI arm64
       shell: |
         make clean
-        make CROSS_COMPILE=aarch64-linux-gnu- ARCH=arm64 \
-        EMBED={{ bootloader_filename }} \
+        make CROSS_COMPILE=aarch64-linux-gnu- \
+             ARCH=arm64 \
+             EMBED={{ bootloader_filename }} \
              TRUST={{ trust_files }} \
              bin-arm64-efi/snp.efi
       args:
         chdir: "{{ ipxe_source_dir }}/src"
       tags:
       - skip_ansible_lint
+      when: ipxe_debug_enabled | bool == false
+
+    - name: Compile iPXE bootloader for EFI arm64 with debug flags
+      shell: |
+        make clean
+        make CROSS_COMPILE=aarch64-linux-gnu- \
+             ARCH=arm64 \
+             DEBUG={{ ipxe_debug_options }} \
+             EMBED={{ bootloader_filename }} \
+             TRUST={{ trust_files }} \
+             bin-arm64-efi/snp.efi
+      args:
+        chdir: "{{ ipxe_source_dir }}/src"
+      tags:
+      - skip_ansible_lint
+      when: ipxe_debug_enabled | bool
 
     - name: Copy iPXE arm64 EFI builds to http directory
       copy:

--- a/roles/netbootxyz/tasks/generate_disks_efi.yml
+++ b/roles/netbootxyz/tasks/generate_disks_efi.yml
@@ -36,7 +36,23 @@
       chdir: "{{ ipxe_source_dir }}/src"
     tags:
     - skip_ansible_lint
+    when: ipxe_debug_enabled | bool == false
 
+  - name: Compile iPXE bootloader for EFI with debug flags
+    shell: |
+      make clean
+      make EMBED={{ bootloader_filename }} \
+           DEBUG={{ ipxe_debug_options }} \
+           TRUST={{ trust_files }} \
+           bin-x86_64-efi/ipxe.efi \
+           bin-x86_64-efi/snp.efi \
+           bin-x86_64-efi/snponly.efi
+    args:
+      chdir: "{{ ipxe_source_dir }}/src"
+    tags:
+    - skip_ansible_lint
+    when: ipxe_debug_enabled | bool
+    
   - name: Copy iPXE EFI builds to http directory
     copy:
       src: "{{ ipxe_source_dir }}/src/{{ item.src }}"

--- a/roles/netbootxyz/tasks/generate_disks_legacy.yml
+++ b/roles/netbootxyz/tasks/generate_disks_legacy.yml
@@ -23,11 +23,33 @@
   - name: Compile iPXE bootloader for Legacy BIOS
     shell: |
       make clean
-      make EMBED={{ bootloader_filename }} TRUST={{ trust_files }} bin/ipxe.dsk bin/ipxe.lkrn bin/ipxe.kpxe bin/undionly.kpxe
+      make EMBED={{ bootloader_filename }} \
+           TRUST={{ trust_files }} \
+           bin/ipxe.dsk \
+           bin/ipxe.lkrn \
+           bin/ipxe.kpxe \
+           bin/undionly.kpxe
     args:
       chdir: "{{ ipxe_source_dir }}/src"
     tags:
     - skip_ansible_lint
+    when: ipxe_debug_enabled | bool == false
+
+  - name: Compile iPXE bootloader for Legacy BIOS with debug flags
+    shell: |
+      make clean
+      make EMBED={{ bootloader_filename }} \
+           DEBUG={{ ipxe_debug_options }} \
+           TRUST={{ trust_files }} \
+           bin/ipxe.dsk \
+           bin/ipxe.lkrn \
+           bin/ipxe.kpxe \
+           bin/undionly.kpxe
+    args:
+      chdir: "{{ ipxe_source_dir }}/src"
+    tags:
+    - skip_ansible_lint
+    when: ipxe_debug_enabled | bool
 
   - name: Copy iPXE files for Legacy BIOS to http directory
     copy:


### PR DESCRIPTION
Enabling the following would enable debug on all images.

ipxe_debug_enabled: true
ipxe_debug_options: httpcore,tls

This will enable toggles to force a build with the
appropriate debug options so that CI can be triggered
to generate a debug image as needed.

By default debug is set to false.