### PR TITLE
Support for Tails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 #### Added
 - Support for Harvester
 - Support for MemTest86 Free
+- Support for Tails
 - Adds additional options for arm64 iPXE binary downloads
 
 ## [2.0.47] - 2021-08-30

--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 | Slackware | https://www.slackware.com | Yes | No |
 | SmartOS | https://www.joyent.com/smartos | Yes | No |
 | SparkyLinux | https://sparkylinux.org/ | No | Yes |
+| Tails | https://tails.boum.org/ | No | Yes |
 | Talos | https://www.talos.dev/ | Yes | No |
 | Tiny Core Linux | https://tinycorelinux.net | Yes | Yes |
 | Ubuntu | https://www.ubuntu.com | Yes | Yes |

--- a/roles/netbootxyz/templates/menu/live-tails.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live-tails.ipxe.j2
@@ -1,0 +1,42 @@
+#!ipxe
+
+# Tails Operating System
+# https://tails.boum.org/
+
+goto ${menu} ||
+
+:live-tails
+clear tails_version
+set os Tails
+set os_arch ${arch}
+iseq ${os_arch} x86_64 && set os_arch amd64 ||
+menu ${os}
+item --gap ${os} Versions
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "tails" %}
+item tails_{{ value.version }} ${space} ${os} {{ value.version }}
+{% endif %}
+{% endfor %}
+choose tails_version || goto tails_exit
+goto ${tails_version}
+
+{% for key, value in endpoints.items() | sort %}
+{% if value.os == "tails" %}
+:tails_{{ value.version }}
+set kernel_url ${live_endpoint}{{ value.path }}
+set iso_version {{ value.version }}
+goto boot
+{% endif %}
+{% endfor %}
+
+:boot
+imgfree
+kernel ${kernel_url}vmlinuz boot=live fromiso=/tails.iso config nopersistence noprompt timezone=Etc/UTC splash noautologin module=Tails slab_nomerge slub_debug=FZP mce=0 vsyscall=none page_poison=1 init_on_free=1 mds=full,nosmt {{ kernel_params }}
+initrd ${kernel_url}initrd.img
+initrd ${kernel_url}9990-misc-helpers.sh /usr/lib/live/boot/9990-misc-helpers.sh
+initrd ${kernel_url}tails-${os_arch}-${iso_version}.iso /tails.iso
+boot
+
+:tails_exit
+clear menu
+exit 0

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -33,6 +33,7 @@ item live-raizo ${space} Live Raizo
 item live-regolith ${space} Regolith
 item live-septor ${space} Septor
 item live-sparky ${space} SparkyLinux
+item live-tails ${space} Tails
 item tinycore ${space} Tiny Core Linux
 item live-ubuntu ${space} Ubuntu
 item live-voyager ${space} Voyager


### PR DESCRIPTION
Adds support for Tails, retrieves modifed 9990-misc-helpers.sh from
upstream live-boot that better handles the fromiso flag to allow for
direct injection of the unmodified tails iso.

Would be nice to see this functionality made available upstream in Tails
to avoid having to override the live-boot hook.