### PR TITLE
🚀 Update Fedora CoreOS versions

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -182,11 +182,11 @@ releases:
     mirror: https://builds.coreos.fedoraproject.org
     name: Fedora CoreOS
     versions:
-    - code_name: 34.20210821.3.0
+    - code_name: 34.20210904.3.0
       name: stable
-    - code_name: 34.20210904.2.0
+    - code_name: 34.20210919.2.0
       name: testing
-    - code_name: 34.20210904.1.0
+    - code_name: 34.20210919.1.0
       name: next
   debian:
     archive_mirror: http://archive.debian.org


### PR DESCRIPTION
Updating to the latest based on the [upstream page](https://getfedora.org/en/coreos/download?tab=cloud_launchable&stream=stable).

Signed-off-by: Major Hayden <major@mhtx.net>