### PR TITLE
Adds rolling release deploy

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -1,0 +1,68 @@
+name: rolling
+
+on:
+  push:
+    paths:
+      - 'endpoints.yml'
+      - 'roles/netbootxyz/defaults/main.yml'
+    branches:
+      - development
+
+env:
+  DISCORD_HOOK_URL: ${{ secrets.DISCORD_HOOK_URL }}
+  GITHUB_SHA: ${{ github.sha }}
+
+jobs:
+  rolling:
+    name: Build Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: 'master'
+
+    - name: Retrieve Certs
+      run: |
+        ./script/retrieve_certs
+      env:
+        GIT_USER: ${{ secrets.GIT_USER }}
+        GIT_AUTH: ${{ secrets.GIT_AUTH }}
+        GIT_URL: ${{ secrets.GIT_URL }}
+        CERTS_KEY: ${{ secrets.CERTS_KEY }}
+
+    - name: Set Release Tag
+      run: echo "release_tag=$(cat version.txt)" >> $GITHUB_ENV
+
+    - name: Download endpoints.yml and main.yml from Development
+      run: |
+        wget https://raw.githubusercontent.com/netbootxyz/netboot.xyz/development/endpoints.yml -O endpoints.yml
+        wget https://raw.githubusercontent.com/netbootxyz/netboot.xyz/development/roles/netbootxyz/defaults/main.yml -O roles/netbootxyz/defaults/main.yml
+
+    - name: Build release
+      run: |
+        ./script/build_release rolling
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_ACCESS_REGION }}
+
+    - name: Deploy master to rolling bucket
+      run: |
+        aws s3 sync --no-progress --acl public-read s3out-latest s3://${{ secrets.AWS_S3_BUCKET_PROD }}
+
+    - name: Invalidate Cloudfront
+      run: |
+        aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DIST_ID_PROD }} --paths "/*" "/ipxe/*"
+
+    - name: Notify Discord on failure
+      if: failure()
+      run: |
+        ./script/message failure
+
+    - name: Notify Discord on completion
+      if: success()
+      run: |
+        ./script/message live-push

--- a/script/build_release
+++ b/script/build_release
@@ -23,38 +23,45 @@ elif [[ "${TYPE}" == "rc" ]]; then
 elif [[ "${TYPE}" == "release" ]]; then
   BOOT_VERSION=$(cat version.txt)
   BOOT_DOMAIN="${PROD_URL}/${BOOT_VERSION}"
+elif [[ "${TYPE}" == "rolling" ]]; then
+  HARD_RELEASE="2.x"
+  PROD_URL="boot.netboot.xyz"
 fi
-sed -i \
-  "/^#boot_version/c\boot_version: \"${BOOT_VERSION}\"" \
-  user_overrides.yml
-sed -i \
-  "/^#boot_domain/c\boot_domain: ${BOOT_DOMAIN}" \
-  user_overrides.yml
 
-# Build release
-docker build -t localbuild -f ${DOCKER_FILE} .
-docker run --rm -i -v $(pwd):/buildout localbuild
+# build release files 
+if ! [[ "${TYPE}" == "rolling" ]]; then
+  sed -i \
+    "/^#boot_version/c\boot_version: \"${BOOT_VERSION}\"" \
+    user_overrides.yml
+  sed -i \
+    "/^#boot_domain/c\boot_domain: ${BOOT_DOMAIN}" \
+    user_overrides.yml
 
-# Generate folder outputs
-mkdir -p s3out
-mkdir -p s3outver
-cp -r buildout/* s3out/
-cp buildout/version.ipxe s3outver/
-mkdir -p githubout
-mv buildout/ipxe/* githubout/
-cd buildout
-rm -Rf ipxe
-tar -czf menus.tar.gz *
-mv menus.tar.gz ../githubout
-cd ..
-if [[ "${TYPE}" == "dev" ]]; then
-  cp githubout/menus.tar.gz s3out/
+  # Build release
+  docker build -t localbuild -f ${DOCKER_FILE} .
+  docker run --rm -i -v $(pwd):/buildout localbuild
+
+  # Generate folder outputs
+  mkdir -p s3out
+  mkdir -p s3outver
+  cp -r buildout/* s3out/
+  cp buildout/version.ipxe s3outver/
+  mkdir -p githubout
+  mv buildout/ipxe/* githubout/
+  cd buildout
+  rm -Rf ipxe
+  tar -czf menus.tar.gz *
+  mv menus.tar.gz ../githubout
+  cd ..
+  if [[ "${TYPE}" == "dev" ]]; then
+    cp githubout/menus.tar.gz s3out/
+  fi
 fi
 
 # Latest style endpoints for RC and Live
-if [[ "${TYPE}" == "release" ]] || [[ "${TYPE}" == "rc" ]]; then
+if [[ "${TYPE}" == "release" ]] || [[ "${TYPE}" == "rolling" ]] || [[ "${TYPE}" == "rc" ]]; then
   rm -Rf buildout/
-  if [[ "${TYPE}" == "release" ]]; then
+  if [[ "${TYPE}" == "release" ]] || [[ "${TYPE}" == "rolling" ]]; then
     sed -i \
       -e "/^boot_version/c\boot_version: \"${HARD_RELEASE}\"" \
       -e "/^boot_domain/c\boot_domain: ${PROD_URL}" \


### PR DESCRIPTION
2.x is designated as a rolling release but usually is aligned
with an actual release.  This commit will allow for updates
to endpoints.yml and the Ansible defaults that contains all
of the version updates to be pushed to boot.netboot.xyz
automatically as they are come in.

This will allow version updates like ArchLinux to be rolled out
immediately once dropped into development without the lag
during releases.

![image](https://user-images.githubusercontent.com/245007/135535947-515e5dfd-a69b-4dfe-a5f7-319dd16d9af2.gif)

Closes https://github.com/netbootxyz/netboot.xyz/issues/1015