### PR TITLE
Adjust ShredOS in README.md (kernel to USB IMG)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 | Redo Rescue | http://redorescue.com/ | LiveCD |
 | Rescatux | https://www.supergrubdisk.org/rescatux/ | LiveCD |
 | Rescuezilla | https://rescuezilla.com/ | LiveCD |
-| ShredOS | https://github.com/PartialVolume/shredos.x86_64 | Kernel | 
+| ShredOS | https://github.com/PartialVolume/shredos.x86_64 | USB Img | 
 | Super Grub2 Disk | http://www.supergrubdisk.org | ISO - Memdisk |
 | System Rescue | https://system-rescue.org/ | LiveCD |
 | The Smallest Server Suite | https://thesss.4mlinux.com/ | Kernel/Initrd |


### PR DESCRIPTION
ShredOS provides an USB .IMG or an .ISO
I think this was copied over from DBAN and not adjusted. Since this is not kernel I would think the current endpoints.yml entry would need to be adjusted as well.

It currently says
```
shredos-x86_64:
    path: /asset-mirror/releases/download/v2020.05.017_x86-64_0.32.003-72b45dbf/
    files:
    - shredos
    os: shredos
    version: v2020.05.017_x86-64_0.32.003
    arch: x86_64

```
but you would think it should be something like
```
 files:
 - shredos.IMG
```