### PR TITLE
Update main.yml

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -332,10 +332,8 @@ releases:
     mirror: http://repo.openeuler.org
     name: openEuler
     versions:
-    - code_name: openEuler-20.03-LTS-SP1
-      name: openEuler-20.03-LTS-SP1
-    - code_name: openEuler-21.03
-      name: openEuler-21.03
+    - code_name: openEuler-20.03-LTS-SP3
+      name: openEuler-20.03-LTS-SP3
     - code_name: openEuler-21.09
       name: openEuler-21.09
   openbsd:


### PR DESCRIPTION
openEuler 20.03 LTS SP3 released.
openEuler 21.03 end of life.