### PR TITLE
revert: Equinix Metal is still Packet

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -475,8 +475,8 @@ releases:
       name: Digital Ocean
     - key: gcp
       name: GCP
-    - key: metal
-      name: Equinix Metal
+    - key: packet
+      name: Packet
     - key: vmware
       name: VMware
   tinycore:

--- a/roles/netbootxyz/tasks/generate_disks_arm.yml
+++ b/roles/netbootxyz/tasks/generate_disks_arm.yml
@@ -74,13 +74,13 @@
         - { src: "bin-arm64-efi/ipxe.efi", dest: "{{ bootloader_filename }}-arm64.efi" }
         - { src: "bin-arm64-efi/snp.efi", dest: "{{ bootloader_filename }}-arm64-snp.efi" }
         - { src: "bin-arm64-efi/snponly.efi", dest: "{{ bootloader_filename }}-arm64-snponly.efi" }
-      when: bootloader_filename != "netboot.xyz-metal"
+      when: bootloader_filename != "netboot.xyz-packet"
 
-    - name: Copy iPXE arm64 EFI builds to http directory for Equinix Metal
+    - name: Copy iPXE arm64 EFI builds to http directory for packet
       copy:
         src: "{{ ipxe_source_dir }}/src/{{ item.src }}"
         dest: "{{ netbootxyz_root }}/ipxe/{{ item.dest }}"
         remote_src: True
       with_items:
         - { src: "bin-arm64-efi/snp.efi", dest: "{{ bootloader_filename }}-arm64.efi" }
-      when: bootloader_filename == "netboot.xyz-metal"
+      when: bootloader_filename == "netboot.xyz-packet"

--- a/roles/netbootxyz/tasks/generate_disks_efi.yml
+++ b/roles/netbootxyz/tasks/generate_disks_efi.yml
@@ -62,13 +62,13 @@
       - { src: "bin-x86_64-efi/ipxe.efi", dest: "{{ bootloader_filename }}.efi" }
       - { src: "bin-x86_64-efi/snp.efi", dest: "{{ bootloader_filename }}-snp.efi" }
       - { src: "bin-x86_64-efi/snponly.efi", dest: "{{ bootloader_filename }}-snponly.efi" }
-    when: bootloader_filename != "netboot.xyz-metal"
+    when: bootloader_filename != "netboot.xyz-packet"
 
-  - name: Copy iPXE EFI builds to http directory for Equinix Metal
+  - name: Copy iPXE EFI builds to http directory for packet
     copy:
       src: "{{ ipxe_source_dir }}/src/{{ item.src }}"
       dest: "{{ netbootxyz_root }}/ipxe/{{ item.dest }}"
       remote_src: True
     with_items:
       - { src: "bin-x86_64-efi/ipxe.efi", dest: "{{ bootloader_filename }}.efi" }
-    when: bootloader_filename == "netboot.xyz-metal"
+    when: bootloader_filename == "netboot.xyz-packet"

--- a/roles/netbootxyz/tasks/generate_disks_legacy.yml
+++ b/roles/netbootxyz/tasks/generate_disks_legacy.yml
@@ -63,7 +63,7 @@
     - ".dsk"
     - ".lkrn"
     - ".kpxe"
-    when: bootloader_filename != "netboot.xyz-metal"
+    when: bootloader_filename != "netboot.xyz-packet"
 
   - name: Copy iPXE files for Legacy BIOS to http directory
     copy:
@@ -72,11 +72,11 @@
       remote_src: True
     with_items:
     - ".kpxe"
-    when: bootloader_filename == "netboot.xyz-metal"
+    when: bootloader_filename == "netboot.xyz-packet"
 
   - name: Copy undionly.kpxe for Legacy BIOS to http directory
     copy:
       src: "{{ ipxe_source_dir }}/src/bin/undionly.kpxe"
       dest: "{{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-undionly.kpxe"
       remote_src: True
-    when: bootloader_filename != "netboot.xyz-metal"
+    when: bootloader_filename != "netboot.xyz-packet"

--- a/roles/netbootxyz/tasks/generate_disks_linux.yml
+++ b/roles/netbootxyz/tasks/generate_disks_linux.yml
@@ -54,4 +54,4 @@
       src: "{{ ipxe_source_dir }}/src/bin-x86_64-linux/slirp.linux"
       dest: "{{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-linux.bin"
       remote_src: True
-    when: bootloader_filename != "netboot.xyz-metal"
+    when: bootloader_filename != "netboot.xyz-packet"

--- a/roles/netbootxyz/templates/disks/netboot.xyz-packet.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz-packet.j2
@@ -10,10 +10,10 @@ set HTTPS_ERR HTTPS appears to have failed... attempting HTTP
 set HTTP_ERR HTTP has failed, localbooting...
 set ipxe_version ${version}
 set version {{ boot_version }}
-set ipxe_cloud_config metal
+set ipxe_cloud_config packet
 
 :start
-echo ${bold}${fg_gre}netboot.xyz ${fg_whi}v${version} for ${fg_red}metal.equinix.com${fg_whi}${boldoff}
+echo ${bold}${fg_gre}netboot.xyz ${fg_whi}v${version} for ${fg_red}packet.com${fg_whi}${boldoff}
 prompt --key m --timeout 4000 Hit the ${bold}m${boldoff} key to open failsafe menu... && goto failsafe || goto dhcp
 
 :dhcp

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -99,30 +99,30 @@ goto clouds
 ###################################
 :clouds
 iseq ${ipxe_cloud_config} gce && goto gce ||
-iseq ${ipxe_cloud_config} metal && goto metal ||
+iseq ${ipxe_cloud_config} packet && goto packet ||
 goto clouds_end
 
 :gce
 set cmdline console=ttyS0,115200n8
 goto clouds_end
 
-:metal
-iseq ${arch} i386 && goto metal_x86_64 ||
-iseq ${arch} x86_64 && goto metal_x86_64 ||
-iseq ${arch} arm64 && goto metal_arm64 ||
+:packet
+iseq ${arch} i386 && goto packet_x86_64 ||
+iseq ${arch} x86_64 && goto packet_x86_64 ||
+iseq ${arch} arm64 && goto packet_arm64 ||
 goto clouds_end
 
-:metal_x86_64
+:packet_x86_64
 set cmdline console=ttyS1,115200n8
-iseq ${platform} efi && set ipxe_disk netboot.xyz-metal.efi || set ipxe_disk netboot.xyz-metal.kpxe
+iseq ${platform} efi && set ipxe_disk netboot.xyz-packet.efi || set ipxe_disk netboot.xyz-packet.kpxe
 set menu_linux_i386 0
 set menu_freedos 0
 set menu_windows 0
 goto clouds_end
 
-:metal_arm64
+:packet_arm64
 set cmdline console=ttyAMA0,115200
-set ipxe_disk netboot.xyz-metal-arm64.efi
+set ipxe_disk netboot.xyz-packet-arm64.efi
 set menu_bsd 0
 set menu_freedos 0
 set menu_live 0

--- a/script/netbootxyz-overrides.yml
+++ b/script/netbootxyz-overrides.yml
@@ -10,7 +10,7 @@ generate_local_vars: false
 bootloader_multiple: true
 bootloader_disks:
   - "netboot.xyz"
-  - "netboot.xyz-metal"
+  - "netboot.xyz-packet"
 generate_signatures: true
 sigs_dir: "{{ netbootxyz_root }}/sigs"
 sigs_location: "http://${boot_domain}/sigs/"


### PR DESCRIPTION
The previous commit cause some trouble with our ability to access SOL, lets revert for now since our boot server boots hasn't been updated to provide the new ipxe_cloud_config value and thus necessary config isn't being picked up on.