### PR TITLE
Use bootloader_filename instead of site_name for bootloader filenames consistently

### DIFF
--- a/roles/netbootxyz/templates/disks/netboot.xyz.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz.j2
@@ -36,12 +36,12 @@ iseq ${use_proxydhcp_settings} true && set tftp-server ${proxydhcp/next-server} 
 goto load-custom-ipxe
 
 :load-custom-ipxe
-isset ${tftp-server} && iseq ${filename} {{ site_name }}.kpxe && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-undionly.kpxe && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}.efi && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-snp.efi && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-snponly.efi && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-arm64.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}.kpxe && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}-undionly.kpxe && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}-snp.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}-snponly.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}-arm64.efi && goto tftpmenu ||
 goto menu
 
 :failsafe

--- a/roles/netbootxyz/templates/index.html.j2
+++ b/roles/netbootxyz/templates/index.html.j2
@@ -48,7 +48,7 @@ exit
     {% for item in bootloaders.hybrid %}
     <tr>
        <td> {{ item.type }} </td>
-       <td> <a href="ipxe/{{ site_name }}{{ item.output_bin }}">{{ site_name }}{{ item.output_bin }}</a> </td>
+       <td> <a href="ipxe/{{ bootloader_filename }}{{ item.output_bin }}">{{ bootloader_filename }}{{ item.output_bin }}</a> </td>
        <td> {{ item.desc }} </td>
     </tr>
     {% endfor %}
@@ -68,7 +68,7 @@ exit
     {% for item in bootloaders.legacy %}
     <tr>
        <td> {{ item.type }} </td>
-       <td> <a href="ipxe/{{ site_name }}{{ item.output_bin }}">{{ site_name }}{{ item.output_bin }}</a> </td>
+       <td> <a href="ipxe/{{ bootloader_filename }}{{ item.output_bin }}">{{ bootloader_filename }}{{ item.output_bin }}</a> </td>
        <td> {{ item.desc }} </td>
     </tr>
     {% endfor %}
@@ -89,7 +89,7 @@ exit
     {% for item in bootloaders.uefi %}
     <tr>
        <td> {{ item.type }} </td>
-       <td> <a href="ipxe/{{ site_name }}{{ item.output_bin }}">{{ site_name }}{{ item.output_bin }}</a> </td>
+       <td> <a href="ipxe/{{ bootloader_filename }}{{ item.output_bin }}">{{ bootloader_filename }}{{ item.output_bin }}</a> </td>
        <td> {{ item.desc }} </td>
     </tr>
     {% endfor %}
@@ -110,7 +110,7 @@ exit
     {% for item in bootloaders.arm %}
     <tr>
        <td> {{ item.type }} </td>
-       <td> <a href="ipxe/{{ site_name }}{{ item.output_bin }}">{{ site_name }}{{ item.output_bin }}</a> </td>
+       <td> <a href="ipxe/{{ bootloader_filename }}{{ item.output_bin }}">{{ bootloader_filename }}{{ item.output_bin }}</a> </td>
        <td> {{ item.desc }} </td>
     </tr>
     {% endfor %}
@@ -131,7 +131,7 @@ exit
     {% for item in bootloaders.rpi %}
     <tr>
        <td> {{ item.type }} </td>
-       <td> <a href="ipxe/{{ site_name }}{{ item.output_bin }}">{{ site_name }}{{ item.output_bin }}</a> </td>
+       <td> <a href="ipxe/{{ bootloader_filename }}{{ item.output_bin }}">{{ bootloader_filename }}{{ item.output_bin }}</a> </td>
        <td> {{ item.desc }} </td>
     </tr>
     {% endfor %}


### PR DESCRIPTION
Fixes #1095
