### PR TITLE
Add trusty to the ubuntu menu

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -607,6 +607,8 @@ releases:
       name: 18.04 LTS Bionic Beaver
     - code_name: xenial
       name: 16.04 LTS Xenial Xerus
+    - code_name: trusty
+      name: 14.04 LTS Trusty Tahr
   vmware:
     enabled: true
     menu: linux


### PR DESCRIPTION
Trusty isn't on http://old-releases.ubuntu.com/ubuntu/dists/ and is still a LTS until 2024.