### PR TITLE
Update fedora kickstart to use inst.ks

### DIFF
--- a/roles/netbootxyz/templates/menu/fedora.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/fedora.ipxe.j2
@@ -61,7 +61,7 @@ goto boot
 
 :kickstart
 echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
-set params ks=${ksurl} ||
+set params inst.ks=${ksurl} ||
 goto boot
 
 :boot


### PR DESCRIPTION
CentOS was fixed back in #583 - add the fix to Fedora as well.

`ks=` is not considered a valid kernel option anymore for Fedora.