### PR TITLE
Fix wrong KDE neon version in endpoints.yml

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -241,7 +241,7 @@ endpoints:
     - filesystem.squashfs
     - initrd.lz
     os: neon
-    version: '20.04'
+    version: '22.04'
     flavor: user
     kernel: kde-neon-user
   regolith-current:


### PR DESCRIPTION
Currently using a version based on Ubuntu 22.04, but `endpoints.yml` contains 20.04

Last commit with KDE neon is https://github.com/netbootxyz/netboot.xyz/commit/52c1375a0668559b971d521d0ef8aa7c234576bb

Sorry, previous PR closed automatically on branch renaming...