### PR TITLE
Update VyOS version name from 1.3-rolling to 1.4 rolling

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -635,7 +635,7 @@ releases:
     name: VyOS
     versions:
     - code_name: rolling
-      name: 1.3 rolling
+      name: 1.4 rolling
   zeninstall:
     enabled: true
     menu: linux


### PR DESCRIPTION
Netboot.xyz has actually been booting VyOS 1.4-rolling from this menu item for a while now, as it’s the publicly available version. Cosmetically, though, it’s said “1.3”, which can be a little confusing. So this PR fixes that.