### PR TITLE
alpine 3.18 -> 3.17.3

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -131,8 +131,8 @@ releases:
     mirror: http://dl-cdn.alpinelinux.org
     name: Alpine Linux
     versions:
-    - code_name: v3.18
-      name: '3.18'
+    - code_name: v3.17.3
+      name: '3.17.3'
     - code_name: edge
       name: Edge (development)
   anarchy:


### PR DESCRIPTION
I'm pretty sure this will get overriden by automated CI/CD but I couldn't find any evidence that v3.18 exists yet (and when I try to use it, it throws an error about not existing)