### PR TITLE
Began adding the return to previous menu prompt to menues.

### DIFF
--- a/roles/netbootxyz/templates/menu/linux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/linux.ipxe.j2
@@ -5,6 +5,7 @@ goto ${menu} ||
 :linux_menu
 menu Linux Installers - Current Arch [ ${arch} ]
 item --gap Linux Distros:
+item linux_exit ${space} Exit back to main menu...
 {% for key, value in releases.items() | sort(attribute='1.name') %}
 {% if value.enabled is defined and value.menu == "linux" and value.enabled | bool %}
 item {{ key }} ${space} {{ value.name }}

--- a/roles/netbootxyz/templates/menu/live.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/live.ipxe.j2
@@ -5,6 +5,7 @@ goto ${menu} ||
 :live_menu
 menu Live Boot Distributions - Current Arch [ ${arch} ]
 item --gap Live Boot Distributions
+item linux_exit ${space} Exit back to main menu...
 item live-backbox ${space} BackBox
 item live-bluestar ${space} Bluestar Linux
 item live-bodhi ${space} Bodhi

--- a/roles/netbootxyz/templates/menu/windows.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/windows.ipxe.j2
@@ -11,6 +11,7 @@ set os Microsoft Windows
 clear win_version
 menu ${os} 
 item --gap Installers
+item linux_exit ${space} Exit back to main menu...
 item win_install ${space} Load ${os} Installer...
 item --gap Options:
 item arch_set ${space} Architecture [ ${win_arch} ]


### PR DESCRIPTION
In as much as I use ProxMox Virtual Environment and use netboot.xyz there within, I use the noVNC console. Hitting the escape key takes the noVNC console out of full screen mode. Thus, I saw the need to add a return to previous menu function to the menues. More menues will likely get this feature added as time goes forth.
