### PR TITLE
Support building images on other architectures

### DIFF
--- a/roles/netbootxyz/tasks/generate_disks_efi.yml
+++ b/roles/netbootxyz/tasks/generate_disks_efi.yml
@@ -27,7 +27,9 @@
 - name: Compile iPXE bootloader for EFI
   ansible.builtin.shell: |
     make clean
-    make EMBED={{ bootloader_filename }} \
+    make CROSS_COMPILE=x86_64-linux-gnu- \
+         ARCH=x86_64 \
+         EMBED={{ bootloader_filename }} \
          TRUST={{ trust_files }} \
          bin-x86_64-efi/ipxe.efi \
          bin-x86_64-efi/snp.efi \
@@ -39,7 +41,9 @@
 - name: Compile iPXE bootloader for EFI with debug flags
   ansible.builtin.shell: |
     make clean
-    make EMBED={{ bootloader_filename }} \
+    make CROSS_COMPILE=x86_64-linux-gnu- \
+         ARCH=x86_64 \
+         EMBED={{ bootloader_filename }} \
          DEBUG={{ ipxe_debug_options }} \
          TRUST={{ trust_files }} \
          bin-x86_64-efi/ipxe.efi \

--- a/roles/netbootxyz/tasks/generate_disks_legacy.yml
+++ b/roles/netbootxyz/tasks/generate_disks_legacy.yml
@@ -23,7 +23,9 @@
 - name: Compile iPXE bootloader for Legacy BIOS
   ansible.builtin.shell: |
     make clean
-    make EMBED={{ bootloader_filename }} \
+    make CROSS_COMPILE=x86_64-linux-gnu- \
+         ARCH=x86_64 \
+         EMBED={{ bootloader_filename }} \
          TRUST={{ trust_files }} \
          bin/ipxe.dsk \
          bin/ipxe.pdsk \
@@ -37,7 +39,9 @@
 - name: Compile iPXE bootloader for Legacy BIOS with debug flags
   ansible.builtin.shell: |
     make clean
-    make EMBED={{ bootloader_filename }} \
+    make CROSS_COMPILE=x86_64-linux-gnu- \
+         ARCH=x86_64 \
+         EMBED={{ bootloader_filename }} \
          DEBUG={{ ipxe_debug_options }} \
          TRUST={{ trust_files }} \
          bin/ipxe.dsk \

--- a/roles/netbootxyz/tasks/generate_disks_linux.yml
+++ b/roles/netbootxyz/tasks/generate_disks_linux.yml
@@ -27,7 +27,9 @@
 - name: Compile iPXE Linux bootloader for Legacy BIOS
   ansible.builtin.shell: |
     make clean
-    make EMBED={{ bootloader_filename }} \
+    make CROSS_COMPILE=x86_64-linux-gnu- \
+         ARCH=x86_64 \
+         EMBED={{ bootloader_filename }} \
          TRUST={{ trust_files }} \
          bin-x86_64-linux/slirp.linux
   args:
@@ -37,7 +39,9 @@
 - name: Compile iPXE Linux bootloader for Legacy BIOS with debug flags
   ansible.builtin.shell: |
     make clean
-    make EMBED={{ bootloader_filename }} \
+    make CROSS_COMPILE=x86_64-linux-gnu- \
+         ARCH=x86_64 \
+         EMBED={{ bootloader_filename }} \
          DEBUG={{ ipxe_debug_options }} \
          TRUST={{ trust_files }} \
          bin-x86_64-linux/slirp.linux

--- a/roles/netbootxyz/vars/debian.yml
+++ b/roles/netbootxyz/vars/debian.yml
@@ -3,15 +3,15 @@ netbootxyz_packages:
   - apache2
   - binutils-dev
   - binutils-aarch64-linux-gnu
+  - binutils-x86-64-linux-gnu
   - dosfstools
   - figlet
   - gcc-aarch64-linux-gnu
+  - gcc-x86-64-linux-gnu
   - build-essential
   - genisoimage
   - git
   - isolinux
   - liblzma-dev
   - libslirp-dev
-  - syslinux
-  - syslinux-common
   - toilet

--- a/roles/netbootxyz/vars/redhat.yml
+++ b/roles/netbootxyz/vars/redhat.yml
@@ -8,6 +8,5 @@ netbootxyz_packages:
   - httpd
   - libslirp-devel
   - minizip-devel
-  - syslinux
   - xz-devel
   - make

--- a/roles/netbootxyz/vars/ubuntu.yml
+++ b/roles/netbootxyz/vars/ubuntu.yml
@@ -3,17 +3,17 @@ netbootxyz_packages:
   - apache2
   - binutils-dev
   - binutils-aarch64-linux-gnu
+  - binutils-x86-64-linux-gnu
   - dosfstools
   - figlet
   - gcc-aarch64-linux-gnu
+  - gcc-x86-64-linux-gnu
   - build-essential
   - genisoimage
   - git
   - isolinux
   - liblzma-dev
   - libslirp-dev
-  - syslinux
-  - syslinux-common
   - toilet
 
 pipxe_packages:


### PR DESCRIPTION
This unconditionally cross compiles all iPXE images. This has the effect that the build will always produce the correct output for a defined architecture regardless of host architecture.

syslinux is x86 architecture dependent. It doesn't seem to be used in the build process, so the packages are removed from the list of required packages.