### PR TITLE
Add OpenBSD 7.3

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -362,6 +362,9 @@ releases:
     mirror: http://ftp.openbsd.org
     name: OpenBSD
     versions:
+    - code_name: '7.3'
+      image_ver: '73'
+      name: '7.3'
     - code_name: '7.2'
       image_ver: '72'
       name: '7.2'


### PR DESCRIPTION
Hello,

This PR add OpenBSD 7.3 to the list of versions for OpenBSD released in April 2023 ([Changelog](https://www.openbsd.org/plus73.html)).