### PR TITLE
Enable CERT_CMD in iPXE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.70] - 2023-00-00
 
+### Added
+
+- Enabled CERT_CMD in iPXE
+- Added Debian 12
+
 ## [2.0.69] - 2023-05-07
 
 ### Added

--- a/roles/netbootxyz/files/ipxe/local/general.h
+++ b/roles/netbootxyz/files/ipxe/local/general.h
@@ -1,3 +1,4 @@
+#define CERT_CMD              /* Certificate management commands */
 #define CONSOLE_CMD           /* Console command */
 #define DIGEST_CMD            /* Image crypto digest commands */
 #define DOWNLOAD_PROTO_HTTPS  /* Secure Hypertext Transfer Protocol */

--- a/roles/netbootxyz/files/ipxe/local/general.h.efi
+++ b/roles/netbootxyz/files/ipxe/local/general.h.efi
@@ -1,3 +1,4 @@
+#define CERT_CMD              /* Certificate management commands */
 #define CONSOLE_CMD           /* Console command */
 #define DIGEST_CMD            /* Image crypto digest commands */
 #define DOWNLOAD_PROTO_HTTPS  /* Secure Hypertext Transfer Protocol */


### PR DESCRIPTION
Enables certificate management commands in iPXE

Closes: https://github.com/netbootxyz/netboot.xyz/issues/1259