### PR TITLE
Update AlmaLinux 8 to 8.8

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -133,8 +133,8 @@ releases:
       name: 9.1
     - code_name: 9.0
       name: 9.0
-    - code_name: 8.7
-      name: 8.7
+    - code_name: 8.8
+      name: 8.8
   alpinelinux:
     base_dir: alpine
     enabled: true


### PR DESCRIPTION
- 8.7 was moved to the vault, so default 8.7 repository links don't work out of the box