### PR TITLE
Fix up vars for RHEL based distros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.71] - 2023-00-00
 
+### Fixed
+
+- Kickstart URLs were broken on RHEL based distros if text install
+  was being used.
+
+
 ## [2.0.70] - 2023-07-03
 
 ### Added

--- a/roles/netbootxyz/templates/menu/almalinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/almalinux.ipxe.j2
@@ -30,8 +30,7 @@ menu ${os} ${os_arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue
-item kickstart ${ova} set kickstart url [ ${ksurl} ]
-item kickstart_device ${ova} set ksdevice [ ${ksdevice} ]
+item kickstart ${ova} set kickstart url [ ${ks_url} ]
 isset ${bt} || choose bt || goto almalinux
 echo ${cls}
 iseq ${bt} text && goto text ||
@@ -40,8 +39,12 @@ iseq ${bt} kickstart && goto kickstart ||
 iseq ${bt} kickstart_device && goto kickstart_device ||
 goto bootos_images
 
+:graphical
+set install_mode inst.graphical ||
+goto bootos_images
+
 :text
-set params inst.text ||
+set install_mode inst.text ||
 goto bootos_images
 
 :rescue
@@ -49,20 +52,14 @@ set params rescue ||
 goto bootos_images
 
 :kickstart
-echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
-set params inst.ks=${ksurl} ||
-clear bt
-goto boottype
-
-:kickstart_device
-echo -n Specify ksdevice param for ${os} ${osversion}: && read ksdevice
-set ksdevice ${ksdevice} ||
+echo -n Specify kickstart URL for ${os} ${osversion}: && read ks_url
+set params inst.ks=${ks_url} ||
 clear bt
 goto boottype
 
 :bootos_images
 imgfree
-kernel ${almalinux_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${params} ${ipparam} {{ kernel_params }}
+kernel ${almalinux_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${install_mode} ${params} ${ipparam} {{ kernel_params }}
 initrd ${almalinux_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/centos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/centos.ipxe.j2
@@ -31,8 +31,7 @@ menu ${os} ${os_arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue
-item kickstart ${ova} set kickstart url [ ${ksurl} ]
-item kickstart_device ${ova} set ksdevice [ ${ksdevice} ]
+item kickstart ${ova} set kickstart url [ ${ks_url} ]
 isset ${bt} || choose bt || goto centos
 echo ${cls}
 iseq ${bt} text && goto text ||
@@ -41,8 +40,12 @@ iseq ${bt} kickstart && goto kickstart ||
 iseq ${bt} kickstart_device && goto kickstart_device ||
 goto bootos_images
 
+:graphical
+set install_mode inst.graphical ||
+goto bootos_images
+
 :text
-set params inst.text ||
+set install_mode inst.text ||
 goto bootos_images
 
 :rescue
@@ -50,14 +53,8 @@ set params rescue ||
 goto bootos_images
 
 :kickstart
-echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
-set params inst.ks=${ksurl} ||
-clear bt
-goto boottype
-
-:kickstart_device
-echo -n Specify ksdevice param for ${os} ${osversion}: && read ksdevice
-set ksdevice ${ksdevice} ||
+echo -n Specify kickstart URL for ${os} ${osversion}: && read ks_url
+set params inst.ks=${ks_url} ||
 clear bt
 goto boottype
 
@@ -66,7 +63,7 @@ imgfree
 iseq ${osversion} 9-stream && set centos_mirror http://mirror.rackspace.com/centos-stream ||
 iseq ${osversion} 9-stream && set dir ${osversion}/BaseOS/${os_arch}/os ||
 iseq ${osversion} 9-stream && set repo ${centos_mirror}/${dir} ||
-kernel ${centos_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${params} ${ipparam} {{ kernel_params }}
+kernel ${centos_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${install_mode} ${params} ${params} ${ipparam} {{ kernel_params }}
 initrd ${centos_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/fedora.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/fedora.ipxe.j2
@@ -46,28 +46,33 @@ menu ${os} ${os_arch} boot type
 item normal ${ova} graphical install
 item text ${ova} text install
 item rescue ${ova} rescue
-item kickstart ${ova} specify kickstart url
+item kickstart ${ova} set kickstart url [ ${ks_url} ]
 isset ${bt} || choose bt || goto fedora
 echo ${cls}
 iseq ${bt} normal && goto boot ||
 goto ${bt}
 
+:graphical
+set install_mode inst.graphical ||
+goto bootos_images
+
 :text
-set params inst.text ||
-goto boot
+set install_mode inst.text ||
+goto bootos_images
 
 :rescue
 set params rescue ||
-goto boot
+goto bootos_images
 
 :kickstart
-echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
-set params inst.ks=${ksurl} ||
-goto boot
+echo -n Specify kickstart URL for ${os} ${osversion}: && read ks_url
+set params inst.ks=${ks_url} ||
+clear bt
+goto boottype
 
 :boot
 imgfree
-kernel ${fedora_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${fedora_mirror}/${dir} ${params} ${ipparam} {{ kernel_params }}
+kernel ${fedora_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${fedora_mirror}/${dir} ${install_mode} ${params} ${ipparam} {{ kernel_params }}
 initrd ${fedora_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/openEuler.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/openEuler.ipxe.j2
@@ -27,8 +27,7 @@ menu ${os} ${arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue
-item kickstart ${ova} set kickstart url [ ${ksurl} ]
-item kickstart_device ${ova} set ksdevice [ ${ksdevice} ]
+item kickstart ${ova} set kickstart url [ ${ks_url} ]
 isset ${bt} || choose bt || goto openEuler
 echo ${cls}
 iseq ${bt} text && goto text ||
@@ -37,8 +36,12 @@ iseq ${bt} kickstart && goto kickstart ||
 iseq ${bt} kickstart_device && goto kickstart_device ||
 goto bootos_images
 
+:graphical
+set install_mode inst.graphical ||
+goto bootos_images
+
 :text
-set params inst.text ||
+set install_mode inst.text ||
 goto bootos_images
 
 :rescue
@@ -46,20 +49,14 @@ set params rescue ||
 goto bootos_images
 
 :kickstart
-echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
-set params inst.ks=${ksurl} ||
-clear bt
-goto boottype
-
-:kickstart_device
-echo -n Specify ksdevice param for ${os} ${osversion}: && read ksdevice
-set ksdevice ${ksdevice} ||
+echo -n Specify kickstart URL for ${os} ${osversion}: && read ks_url
+set params inst.ks=${ks_url} ||
 clear bt
 goto boottype
 
 :bootos_images
 imgfree
-kernel ${openEuler_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${params} ${ipparam} {{ kernel_params }}
+kernel ${openEuler_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${install_mode} ${params} ${ipparam} {{ kernel_params }}
 initrd ${openEuler_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:

--- a/roles/netbootxyz/templates/menu/rockylinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/rockylinux.ipxe.j2
@@ -30,18 +30,20 @@ menu ${os} ${os_arch} boot type
 item graphical ${ova} graphical installer
 item text ${ova} text based installer
 item rescue ${ova} rescue
-item kickstart ${ova} set kickstart url [ ${ksurl} ]
-item kickstart_device ${ova} set ksdevice [ ${ksdevice} ]
+item kickstart ${ova} set kickstart url [ ${ks_url} ]
 isset ${bt} || choose bt || goto rockylinux
 echo ${cls}
 iseq ${bt} text && goto text ||
 iseq ${bt} rescue && goto rescue ||
 iseq ${bt} kickstart && goto kickstart ||
-iseq ${bt} kickstart_device && goto kickstart_device ||
+goto bootos_images
+
+:graphical
+set install_mode inst.graphical ||
 goto bootos_images
 
 :text
-set params inst.text ||
+set install_mode inst.text ||
 goto bootos_images
 
 :rescue
@@ -49,20 +51,14 @@ set params rescue ||
 goto bootos_images
 
 :kickstart
-echo -n Specify kickstart URL for ${os} ${osversion}: && read ksurl
-set params inst.ks=${ksurl} ||
-clear bt
-goto boottype
-
-:kickstart_device
-echo -n Specify ksdevice param for ${os} ${osversion}: && read ksdevice
-set ksdevice ${ksdevice} ||
+echo -n Specify kickstart URL for ${os} ${osversion}: && read ks_url
+set params inst.ks=${ks_url} ||
 clear bt
 goto boottype
 
 :bootos_images
 imgfree
-kernel ${rockylinux_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${params} ${ipparam} {{ kernel_params }}
+kernel ${rockylinux_mirror}/${dir}/images/pxeboot/vmlinuz inst.repo=${repo} ${install_mode} ${params} ${ipparam} {{ kernel_params }}
 initrd ${rockylinux_mirror}/${dir}/images/pxeboot/initrd.img
 echo
 echo MD5sums:


### PR DESCRIPTION
Kickstart URLs were getting overriden if using text based. Split out the vars so this should be corrected now