### PR TITLE
update Scientific Linux Version

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -426,14 +426,14 @@ releases:
     mirror: http://ftp1.scientificlinux.org
     name: Scientific Linux
     versions:
+    - code_name: '7.9'
+      name: '7.9'
+    - code_name: '7.8'
+      name: '7.8'
     - code_name: '7.7'
       name: '7.7'
     - code_name: '7.6'
       name: '7.6'
-    - code_name: '6.10'
-      name: '6.10'
-    - code_name: '6.9'
-      name: '6.9'
   slackware:
     base_dir: slackware
     enabled: true


### PR DESCRIPTION
update Scientific Linux Versions

6.9 and 6.10 removed
7.8 and 7.9 added