### PR TITLE
Update tails distribution URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 | Slackware | https://www.slackware.com | Yes | No |
 | SmartOS | https://www.joyent.com/smartos | Yes | No |
 | SparkyLinux | https://sparkylinux.org/ | No | Yes |
-| Tails | https://tails.boum.org/ | No | Yes |
+| Tails | https://tails.net | No | Yes |
 | Talos | https://www.talos.dev/ | Yes | No |
 | Tiny Core Linux | https://tinycorelinux.net | Yes | Yes |
 | Ubuntu | https://www.ubuntu.com | Yes | Yes |


### PR DESCRIPTION
Tails has officially moved to https://tails.net/ and the current URL (in README) redirects to this new URL.