### PR TITLE
Add arm64 image generation and allow for independent image generation

### DIFF
--- a/roles/netbootxyz/tasks/generate_disks.yml
+++ b/roles/netbootxyz/tasks/generate_disks.yml
@@ -33,7 +33,4 @@
   ansible.builtin.include_tasks: generate_disks_hybrid.yml
   when:
     - generate_disks_hybrid | default(false) | bool
-    - generate_disks_legacy | default(true) | bool
-    - generate_disks_efi | default(true) | bool
-    - generate_disks_arm | default(false) | bool
     - bootloader_filename == "netboot.xyz"

--- a/roles/netbootxyz/tasks/generate_disks_hybrid.yml
+++ b/roles/netbootxyz/tasks/generate_disks_hybrid.yml
@@ -11,6 +11,7 @@
   when: 
     - generate_disks_hybrid | default(false) | bool
     - generate_disks_legacy | default(true) | bool
+    - generate_disks_efi | default(true) | bool
 
 
 - name: Generate hybrid ISO multiarch image
@@ -26,6 +27,7 @@
     - generate_disks_hybrid | default(false) | bool
     - generate_disks_legacy | default(true) | bool
     - generate_disks_arm | default(false) | bool
+    - generate_disks_efi | default(true) | bool
 
 - name: Generate hybrid ISO arm64 image
   ansible.builtin.shell: |
@@ -49,6 +51,7 @@
   when:
     - generate_disks_hybrid | default(false) | bool
     - generate_disks_legacy | default(true) | bool
+    - generate_disks_efi | default(true) | bool
 
 - name: Generate hybrid USB multiarch image
   ansible.builtin.shell: |
@@ -63,6 +66,7 @@
     - generate_disks_hybrid | default(false) | bool
     - generate_disks_legacy | default(true) | bool
     - generate_disks_arm | default(false) | bool
+    - generate_disks_efi | default(true) | bool
 
 - name: Generate hybrid USB arm64 image
   ansible.builtin.shell: |

--- a/roles/netbootxyz/tasks/generate_disks_hybrid.yml
+++ b/roles/netbootxyz/tasks/generate_disks_hybrid.yml
@@ -8,6 +8,10 @@
       {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.lkrn
   args:
     chdir: "{{ ipxe_source_dir }}/src"
+  when: 
+    - generate_disks_hybrid | default(false) | bool
+    - generate_disks_legacy | default(true) | bool
+
 
 - name: Generate hybrid ISO multiarch image
   ansible.builtin.shell: |
@@ -18,6 +22,10 @@
       {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-arm64.efi
   args:
     chdir: "{{ ipxe_source_dir }}/src"
+  when:
+    - generate_disks_hybrid | default(false) | bool
+    - generate_disks_legacy | default(true) | bool
+    - generate_disks_arm | default(false) | bool
 
 - name: Generate hybrid USB x86_64 image
   ansible.builtin.shell: |
@@ -27,6 +35,9 @@
       {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.lkrn
   args:
     chdir: "{{ ipxe_source_dir }}/src"
+  when:
+    - generate_disks_hybrid | default(false) | bool
+    - generate_disks_legacy | default(true) | bool
 
 - name: Generate hybrid USB multiarch image
   ansible.builtin.shell: |
@@ -37,3 +48,7 @@
       {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-arm64.efi
   args:
     chdir: "{{ ipxe_source_dir }}/src"
+  when:
+    - generate_disks_hybrid | default(false) | bool
+    - generate_disks_legacy | default(true) | bool
+    - generate_disks_arm | default(false) | bool

--- a/roles/netbootxyz/tasks/generate_disks_hybrid.yml
+++ b/roles/netbootxyz/tasks/generate_disks_hybrid.yml
@@ -27,6 +27,17 @@
     - generate_disks_legacy | default(true) | bool
     - generate_disks_arm | default(false) | bool
 
+- name: Generate hybrid ISO arm64 image
+  ansible.builtin.shell: |
+    ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-arm64.iso \
+      -s {{ bootloader_filename }} \
+      {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-arm64.efi
+  args:
+    chdir: "{{ ipxe_source_dir }}/src"
+  when:
+    - generate_disks_hybrid | default(false) | bool
+    - generate_disks_arm | default(false) | bool
+
 - name: Generate hybrid USB x86_64 image
   ansible.builtin.shell: |
     ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.img \
@@ -51,4 +62,15 @@
   when:
     - generate_disks_hybrid | default(false) | bool
     - generate_disks_legacy | default(true) | bool
+    - generate_disks_arm | default(false) | bool
+
+- name: Generate hybrid USB arm64 image
+  ansible.builtin.shell: |
+    ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-arm64.img \
+      -s {{ bootloader_filename }} \
+      {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}-arm64.efi
+  args:
+    chdir: "{{ ipxe_source_dir }}/src"
+  when:
+    - generate_disks_hybrid | default(false) | bool
     - generate_disks_arm | default(false) | bool


### PR DESCRIPTION
This merge does two things:

1. Allows for independent image generation for ISO/IMG
2. Generate arm64 ISO/IMG files

ISO/IMG are only generated when `generate_disks_legacy`, `generate_disks_arm` and `generate_disks_efi` are set to `true` as well as `generate_disks_hybrid`. I believe any image should be able to be generated independently without having to have all of them generated. The code looks at the variables set and addresses this issue by explicitly declaring dependencies

The second change adds arm64 ISO/IMG generation. With an increasing number of desktops/SBCs using arm64, images for this architecture would be useful.

May be worth adding in separate images for legacy and EFI so image generation times can be cut down.