### PR TITLE
Relax checks on tftp filename in bootloader

### DIFF
--- a/roles/netbootxyz/templates/disks/netboot.xyz.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz.j2
@@ -39,12 +39,7 @@ iseq ${use_proxydhcp_settings} true && set tftp-server ${proxydhcp/next-server} 
 goto load-custom-ipxe
 
 :load-custom-ipxe
-isset ${tftp-server} && iseq ${filename} {{ site_name }}.kpxe && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-undionly.kpxe && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}.efi && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-snp.efi && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-snponly.efi && goto tftpmenu ||
-isset ${tftp-server} && iseq ${filename} {{ site_name }}-arm64.efi && goto tftpmenu ||
+isset ${tftp-server} && isset ${filename} && goto tftpmenu ||
 goto menu
 
 :failsafe


### PR DESCRIPTION
Previously checks for tftp-server and filename were hard set to search for certain files to load.

This relaxes that check and if next-server and filename are set it will attempt to load the local menu.