### PR TITLE
Update Talos PXE menu, platforms, and add custom_kernel_params

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -751,13 +751,6 @@ endpoints:
     version: '20.3'
     flavor: Cinnamon
     kernel: mint-20-cinnamon-squash
-  talos:
-    path: /asset-mirror/releases/download/0.13.4-3f5e10e5/
-    files:
-    - vmlinuz
-    - initramfs.xz
-    os: talos
-    version: 0.13.4
   elementaryos-6-default-squash:
     path: /ubuntu-squash/releases/download/6-3e90a5ea/
     files:
@@ -1338,13 +1331,6 @@ endpoints:
     version: jammy
     flavor: jammy
     kernel: voyager-jammy-squash
-  talos-amd64:
-    path: /asset-mirror/releases/download/1.0.4-9616af8f/
-    files:
-    - vmlinuz-amd64
-    - initramfs-amd64.xz
-    os: talos
-    version: 1.0.4
   pop-22.04-default-squash:
     path: /ubuntu-squash/releases/download/21-a9399656/
     files:

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -470,6 +470,11 @@ releases:
       name: 20231102T000310Z
   talos:
     enabled: true
+    # Talos kernel parameter reference https://www.talos.dev/latest/reference/kernel/
+    # custom_kernel_params: printk.devkmsg=on slab_nomerge pti=on talos.platform=${talos_platform}
+    #   ${talos_config} console=ttyS0 console=tty0 init_on_alloc=1 init_on_free=1 consoleblank=0
+    #   nvme_core.io_timeout=4294967295 ima_template=ima-ng ima_appraise=fix ima_hash=sha512
+    #   initrd=initrd.magic ${cmdline}
     menu: linux
     mirror: https://github.com/siderolabs/talos/releases
     name: Talos
@@ -480,14 +485,28 @@ releases:
       name: AWS
     - key: azure
       name: Azure
-    - key: digital-ocean
+    - key: digitalocean
       name: Digital Ocean
+    - key: equinixMetal
+      name: Equinix Metal
     - key: gcp
       name: GCP
-    - key: metal
-      name: Equinix Metal
+    - key: hcloud
+      name: Hetzner Cloud
+    - key: nocloud
+      name: Nocloud
+    - key: openstack
+      name: Openstack
+    - key: oracle
+      name: oracle
+    - key: scaleway
+      name: Scaleway
+    - key: upcloud
+      name: Upcloud
     - key: vmware
       name: VMware
+    - key: vultr
+      name: Vultr
   tinycore:
     enabled: true
     menu: linux

--- a/roles/netbootxyz/templates/menu/talos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/talos.ipxe.j2
@@ -2,7 +2,7 @@
 
 # Talos
 # https://github.com/siderolabs/talos/releases
-# https://www.talos.dev/v1.0/talos-guides/install/bare-metal-platforms/matchbox/
+# https://www.talos.dev/v1.6/talos-guides/install/bare-metal-platforms/pxe
 
 goto ${menu} ||
 
@@ -59,6 +59,7 @@ echo -n Set userdata.yaml URL:  && read talos_config_url
 clear menu
 goto talos
 
+# https://www.talos.dev/latest/reference/kernel/#talosplatform
 :talos_platform
 menu ${os} platforms
 {% for item in releases.talos.platforms %}
@@ -67,10 +68,16 @@ item {{ item.key }} ${space} {{ item.name }}
 choose --default ${talos_platform} talos_platform
 goto talos
 
+# https://www.talos.dev/latest/reference/kernel/
 :talos_boot
 isset ${talos_base_url} || set talos_base_url ${talos_mirror}/latest/download
 isset ${talos_config_url} && set talos_config talos.config=${talos_config_url} ||
-set boot_params page_poison=1 printk.devkmsg=on slab_nomerge slub_debug=P pti=on talos.platform=${talos_platform} ${talos_config} {{ kernel_params }}
+{# Edit releases.talos.custom_kernel_params in main.yml for custom kernel params #}
+{% if releases.talos.custom_kernel_params is defined and releases.talos.custom_kernel_params %}
+set boot_params {{ releases.talos.kernel_params }}
+{% else %}
+set boot_params printk.devkmsg=on slab_nomerge pti=on console=ttyS0 console=tty0 init_on_alloc=1 init_on_free=1 consoleblank=0 nvme_core.io_timeout=4294967295 ima_template=ima-ng ima_appraise=fix ima_hash=sha512 talos.platform=${talos_platform} ${talos_config} initrd=initrd.magic ${cmdline}
+{% endif %}
 imgfree
 kernel ${talos_base_url}/vmlinuz-${os_arch} ${boot_params}
 initrd ${talos_base_url}/initramfs-${os_arch}.xz


### PR DESCRIPTION
The second commit in the PR cleans up the Talos.ipxe menu, adds a new argument called `custom_kernel_params` that can be used to modify the parameters passed to the Talos kernel specifically, and adds a number of new supported arguments for the `talos.platform` variable (and fixes some platform names).

The other commit removes the old `talos` and `talos-amd64` entries from `endpoints.yml` since they're very old and haven't been updated in quite a while in [asset-mirror](https://github.com/netbootxyz/asset-mirror) (since there are no longer any talos-related branches). I've created the required files in a branch in my own repo here but I am unsure how to open a PR to a branch that doesn't exist in the upstream repo. Anyway, you can review those two branches [here](https://github.com/goproslowyo/asset-mirror/tree/talos-amd64) and [here](https://github.com/goproslowyo/asset-mirror/tree/talos-arm64) and they should get updated Talos entries generated in `endpoints.yml`. If those branches are useful let me know how to proceed.
