### PR TITLE
Keep legacy memtest 5.x version

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -738,12 +738,18 @@ utilitiespcbios32:
     enabled: true
     name: Clonezilla
     type: ipxemenu
+  memtest86legacy:
+    enabled: true
+    name: Memtest86+ 5.01.0
+    type: memtest
+    util_path: https://boot.netboot.xyz/utils/memtest86-5.01.0
+    version: 5.01.0
   memtest86plus:
     enabled: true
-    name: Memtest86+ - {{ endpoints.memtest86plus.version }}
-    type: memtest
     util_path: ${live_endpoint}{{ endpoints.memtest86plus.path }}memtest32.bin
-    version: '{{ endpoints.memtest86plus.version }}'
+    name: Memtest86+ {{ endpoints.memtest86plus.version }}
+    version: "{{ endpoints.memtest86plus.version }}"
+    type: memtest
   shredos:
     enabled: true
     name: ShredOS
@@ -800,6 +806,12 @@ utilitiespcbios64:
     enabled: true
     name: Kaspersky Rescue Disk
     type: ipxemenu
+  memtest86legacy:
+    enabled: true
+    name: Memtest86+ 5.01.0
+    type: memtest
+    util_path: https://boot.netboot.xyz/utils/memtest86-5.01.0
+    version: 5.01.0
   memtest86plus:
     enabled: true
     name: Memtest86+ - {{ endpoints.memtest86plus.version }}

--- a/roles/netbootxyz/templates/menu/utils-pcbios-32.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-pcbios-32.ipxe.j2
@@ -60,6 +60,7 @@ echo
 echo -n Enter cmdline parameters: ${} && read cmdline
 goto utils_menu
 
+:memtest86legacy
 :memtest86plus
 imgfree
 kernel {{ utilitiespcbios32.memtest86plus.util_path }}

--- a/roles/netbootxyz/templates/menu/utils-pcbios-64.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/utils-pcbios-64.ipxe.j2
@@ -60,6 +60,7 @@ echo
 echo -n Enter cmdline parameters: ${} && read cmdline
 goto utils_menu
 
+:memtest86legacy
 :memtest86plus
 imgfree
 kernel {{ utilitiespcbios64.memtest86plus.util_path }}


### PR DESCRIPTION
Saw some oddities with Proxmox and loading bin, but seems to work with VMware. Leaving the older version as it may work for some and will allow for users to test on it.