### PR TITLE
SmartOS has moved to MNX.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ In addition to being able to host netboot.xyz locally, you can also create your 
 | Scientific Linux | https://scientificlinux.org | Yes | No |
 | Septor | https://septor.sourceforge.io | No | Yes |
 | Slackware | https://www.slackware.com | Yes | No |
-| SmartOS | https://www.joyent.com/smartos | Yes | No |
+| SmartOS | https://www.smartos.org/ | Yes | No |
 | SparkyLinux | https://sparkylinux.org/ | No | Yes |
 | Tails | https://tails.net | No | Yes |
 | Talos | https://www.talos.dev/ | Yes | No |

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -457,7 +457,7 @@ releases:
     base_dir: /platform/i86pc/
     enabled: true
     menu: unix
-    mirror: https://netboot.joyent.com/os/
+    mirror: https://netboot.smartos.org/os/
     name: SmartOS
     versions:
     - code_name: 20231228T001409Z

--- a/roles/netbootxyz/templates/menu/smartos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/smartos.ipxe.j2
@@ -1,7 +1,7 @@
 #!ipxe
 ######################################
 # SmartOS                            #
-# https://www.joyent.com/smartos     #
+# https://www.smartos.org/           #
 # Credit: https://github.com/bahamat #
 ######################################
 
@@ -28,7 +28,7 @@ item toggle_kmdb_b ${space} Boot Kernel Debugger First: ${kmdb_b}
 
 iseq ${noimport} true && item --gap ${space} ||
 iseq ${noimport} true && item --gap ${space} Zpool will not be imported. Rescue mode root password can be found at ||
-iseq ${noimport} true && item --gap ${space} http://us-east.manta.joyent.com/Joyent_Dev/public/SmartOS/smartos.html ||
+iseq ${noimport} true && item --gap ${space} http://us-central.manta.mnx.io/Joyent_Dev/public/SmartOS/smartos.html ||
 
 choose smartos_build || goto smartos_exit
 iseq ${smartos_build} toggle_pool && goto toggle_pool ||

--- a/roles/netbootxyz/templates/menu/smartos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/smartos.ipxe.j2
@@ -28,7 +28,7 @@ item toggle_kmdb_b ${space} Boot Kernel Debugger First: ${kmdb_b}
 
 iseq ${noimport} true && item --gap ${space} ||
 iseq ${noimport} true && item --gap ${space} Zpool will not be imported. Rescue mode root password can be found at ||
-iseq ${noimport} true && item --gap ${space} http://us-central.manta.mnx.io/Joyent_Dev/public/SmartOS/smartos.html ||
+iseq ${noimport} true && item --gap ${space} https://us-central.manta.mnx.io/Joyent_Dev/public/SmartOS/smartos.html ||
 
 choose smartos_build || goto smartos_exit
 iseq ${smartos_build} toggle_pool && goto toggle_pool ||


### PR DESCRIPTION
Hello!

SmartOS (and Triton) have moved out of Samsung to [MNX](https://mnx.io). Joyent has kept compatibility domain names for us, but it's time to switch everything over to their canonical URLs.

Along with this pull request, I have opened netbootxyz/netboot.xyz-docs#97.

If there is any infrastructure that references Joyent outside of github, I can help get that redirected to the proper location as well.