### PR TITLE
Fix missing hash in Talos template

### DIFF
--- a/roles/netbootxyz/templates/menu/talos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/talos.ipxe.j2
@@ -1,4 +1,4 @@
-!ipxe
+#!ipxe
 
 # Talos
 # https://github.com/siderolabs/talos/releases


### PR DESCRIPTION
This prevented Talos from booting with a `Exec format error` from iPXE