### PR TITLE
Add alternative mode for System Rescue with 'rootpass' as MAC address

### DIFF
--- a/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
@@ -15,6 +15,7 @@ item --gap ${os} Versions
 iseq ${os_arch} {{ value.arch }} && item {{ value.version }}_${os_arch} ${space} ${os} {{ value.version }} ||
 {% endif %}
 {% endfor %}
+item rootpass_mac Enable rootpass=MAC_ADDRESS
 choose live_version || goto live_exit
 goto ${live_version}
 
@@ -27,9 +28,13 @@ goto boot
 {% endif %}
 {% endfor %}
 
+:rootpass_mac
+iseq ${rootpass_enabled} true && set rootpass_enabled false || set rootpass_enabled true && set params rootpass=${netX/mac} 
+goto live_menu
+
 :boot
 imgfree
-kernel ${url}vmlinuz archisobasedir=sysresccd ${ipparam} archiso_http_srv=${url} {{ kernel_params }}
+kernel ${url}vmlinuz archisobasedir=sysresccd ${ipparam} archiso_http_srv=${url} ${params} {{ kernel_params }}
 initrd ${url}initrd
 boot
 


### PR DESCRIPTION
Related to #1441

Adds a new menu entry to the System Rescue CD Tools menu in `roles/netbootxyz/templates/menu/systemrescue.ipxe.j2` to enable setting the 'rootpass' boot parameter to the device's MAC address.

- **New Menu Entry**: Introduces an option labeled "Enable rootpass=MAC_ADDRESS" that allows users to toggle the 'rootpass' parameter to the MAC address of the device.
- **Conditional Logic**: Implements conditional logic to enable or disable the 'rootpass' parameter based on the user's selection from the new menu entry.
- **Parameter Passing**: Modifies the boot command to include the 'rootpass' parameter when enabled, ensuring the root password is set to the device's MAC address for easier access.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/netbootxyz/netboot.xyz/issues/1441?shareId=a21aeddc-a7a4-4e8b-8df6-582a6bf7f7c3).