### PR TITLE
Add alternative mode for System Rescue with 'rootpass' as MAC address

### DIFF
--- a/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/systemrescue.ipxe.j2
@@ -5,6 +5,7 @@ goto ${menu} ||
 :live_menu
 set os System Rescue
 set os_arch ${arch}
+isset ${rootpass_enabled} || set rootpass_enabled false
 iseq ${os_arch} x86_64 && set os_arch amd64 ||
 iseq ${os_arch} i386 && set os_arch i686 ||
 menu ${os}
@@ -15,6 +16,7 @@ item --gap ${os} Versions
 iseq ${os_arch} {{ value.arch }} && item {{ value.version }}_${os_arch} ${space} ${os} {{ value.version }} ||
 {% endif %}
 {% endfor %}
+item rootpass_mac Enable rootpass=MAC_ADDRESS [ enabled: ${rootpass_enabled} ]
 choose live_version || goto live_exit
 goto ${live_version}
 
@@ -27,9 +29,14 @@ goto boot
 {% endif %}
 {% endfor %}
 
+:rootpass_mac
+clear params
+iseq ${rootpass_enabled} true && set rootpass_enabled false || set rootpass_enabled true && set params rootpass=${netX/mac}
+goto live_menu
+
 :boot
 imgfree
-kernel ${url}vmlinuz archisobasedir=sysresccd ${ipparam} archiso_http_srv=${url} {{ kernel_params }}
+kernel ${url}vmlinuz archisobasedir=sysresccd ${ipparam} archiso_http_srv=${url} ${params} {{ kernel_params }}
 initrd ${url}initrd
 boot
 


### PR DESCRIPTION
Related to #1441

Adds a new menu entry to the System Rescue CD Tools menu in `roles/netbootxyz/templates/menu/systemrescue.ipxe.j2` to enable setting the 'rootpass' boot parameter to the device's MAC address.

- **New Menu Entry**: Introduces an option labeled "Enable rootpass=MAC_ADDRESS" that allows users to set the 'rootpass' boot parameter to their device's MAC address for easier access.
- **Toggle Functionality**: Implements a toggle mechanism that enables or disables the 'rootpass' parameter based on the user's selection from the menu. This is achieved through a conditional check that sets or unsets the `rootpass_enabled` flag and the `params` variable accordingly.
- **Dynamic Parameter Setting**: Modifies the boot command to dynamically include the `rootpass` parameter with the MAC address value when the option is enabled by the user.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/netbootxyz/netboot.xyz/issues/1441?shareId=fbe09b2b-f200-48de-8916-542859299786).