### PR TITLE
Update boot.cfg.j2

### DIFF
--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -29,8 +29,8 @@ set boot_timeout {{ boot_timeout }}
 # Media Locations for Licensed Distros
 ######################################
 
-set rhel_base_url {{ rhel_base_url | default("") }}
-set win_base_url {{ win_base_url | default("") }}
+isset ${rhel_base_url} || set rhel_base_url {{ rhel_base_url | default("") }}
+isset ${win_base_url} || set win_base_url {{ win_base_url | default("") }}
 
 ##################
 # official mirrors


### PR DESCRIPTION
Allow users to set their own values for win_base_url and rhel_base_url from local-vars

This is to resolve the following bug (by allowing users to set their own win_base_url)

https://github.com/netbootxyz/netboot.xyz/issues/1344

