### PR TITLE
Remove hardcoded console=ttyS0,115200 configuration from VyOS boot configuration

### DIFF
--- a/roles/netbootxyz/templates/menu/vyos.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/vyos.ipxe.j2
@@ -18,7 +18,7 @@ goto vyos_boot
 :vyos_boot
 imgfree
 set url ${live_endpoint}{{ endpoints['vyos-rolling'].path }}
-kernel ${url}vmlinuz boot=live components hostname=vyos username=live nopersistence noautologin union=overlay console=ttyS0,115200 console=tty0 net.ifnames=0 biosdevname=0 fetch=${url}filesystem.squashfs {{ kernel_params }}
+kernel ${url}vmlinuz boot=live components hostname=vyos username=live nopersistence noautologin union=overlay console=tty0 net.ifnames=0 biosdevname=0 fetch=${url}filesystem.squashfs {{ kernel_params }}
 initrd ${url}initrd
 
 boot


### PR DESCRIPTION
This change removes the console=ttyS0,115200 configuration from the VyOS boot configuration in roles/netbootxyz/templates/menu/boot.cfg.j2. This setting is causing issues with VyOS installation on Equinix Metal as the console is not visible during boot.

Console configuration is done in https://github.com/netbootxyz/netboot.xyz/blob/development/roles/netbootxyz/templates/menu/boot.cfg.j2

Examples:
x86_64 https://github.com/netbootxyz/netboot.xyz/blob/development/roles/netbootxyz/templates/menu/boot.cfg.j2#L120
arm64 https://github.com/netbootxyz/netboot.xyz/blob/development/roles/netbootxyz/templates/menu/boot.cfg.j2#L129