### PR TITLE
Add DTS v2.0.0

### DIFF
--- a/endpoints.yml
+++ b/endpoints.yml
@@ -394,6 +394,13 @@ endpoints:
     - vmlinuz
     os: caine
     version: '13.0'
+  dts:
+    path: /dts/v2.0.0
+    files:
+    - initrd
+    - vmlinuz
+    os: dts
+    version: '2.0.0'
   bootrepair:
     path: /ubuntu-squash/releases/download/current-e035b00c/
     files:

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -662,6 +662,12 @@ utilitiesefi:
     enabled: true
     name: Clonezilla
     type: ipxemenu
+  dts:
+    enabled: true
+    name: Dasharo Tools Suite
+    initrd: https://boot.dasharo.com{{ endpoints.dts.path }}/dts-base-image-v{{ endpoints.dts.version }}.cpio.gz
+    kernel: https://boot.dasharo.com{{ endpoints.dts.path }}/bzImage-v{{ endpoints.dts.version }}
+    type: direct
   gparted:
     enabled: true
     name: GParted
@@ -762,6 +768,12 @@ utilitiespcbios64:
     enabled: true
     name: DBAN
     type: ipxemenu
+  dts:
+    enabled: true
+    name: Dasharo Tools Suite
+    initrd: https://boot.dasharo.com{{ endpoints.dts.path }}/dts-base-image-v{{ endpoints.dts.version }}.cpio.gz
+    kernel: https://boot.dasharo.com{{ endpoints.dts.path }}/bzImage-v{{ endpoints.dts.version }}
+    type: direct
   gparted:
     enabled: true
     name: GParted


### PR DESCRIPTION
Dasharo Tools Suite (DTS) is a set of tools running in a minimal Linux environment to deploy, update, and maintain firmware on Dasharo-supported devices. For example, it can be used to update the firmware on a device or run the initial deployment, even when no OS is currently installed. https://docs.dasharo.com/dasharo-tools-suite/overview/