### PR TITLE
EFI: Add floppy images

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -88,6 +88,14 @@ bootloaders:
     ipxe_bin: snponly.efi
     output_bin: -snponly.efi
     type: DHCP-snponly
+  - desc: DHCP EFI Floppy boot image file, uses built-in iPXE NIC drivers
+    ipxe_bin: ipxe.efi.dsk
+    output_bin: .efi.dsk
+    type: Floppy
+  - desc: EFI Floppy image w/ Simple Network Protocol, attempts to boot all net devices
+    ipxe_bin: snp.efi.dsk
+    output_bin: -snp.efi.dsk
+    type: Floppy-snp
 cert_dir: /etc/netbootxyz/certs
 cert_file_filename: ca-netboot-xyz.crt
 checksums_filename: '{{ site_name }}-sha256-checksums.txt'

--- a/roles/netbootxyz/tasks/generate_disks_efi.yml
+++ b/roles/netbootxyz/tasks/generate_disks_efi.yml
@@ -51,6 +51,18 @@
     chdir: "{{ ipxe_source_dir }}/src"
   when: ipxe_debug_enabled | bool
 
+- name: Generate iPXE floppy images for EFI
+  ansible.builtin.shell: |
+    truncate -s 1440k bin-x86_64-efi/ipxe.efi.dsk
+    mformat -i bin-x86_64-efi/ipxe.efi.dsk -f 1440 ::
+    mmd -i bin-x86_64-efi/ipxe.efi.dsk ::EFI
+    mmd -i bin-x86_64-efi/ipxe.efi.dsk ::EFI/BOOT
+    cp bin-x86_64-efi/ipxe.efi.dsk bin-x86_64-efi/snp.efi.dsk
+    mcopy -i bin-x86_64-efi/ipxe.efi.dsk  bin-x86_64-efi/ipxe.efi ::EFI/BOOT/BOOTX64.EFI
+    mcopy -i bin-x86_64-efi/snp.efi.dsk  bin-x86_64-efi/snp.efi ::EFI/BOOT/BOOTX64.EFI
+  args:
+    chdir: "{{ ipxe_source_dir }}/src"
+
 - name: Copy iPXE EFI builds to http directory
   ansible.builtin.copy:
     src: "{{ ipxe_source_dir }}/src/{{ item.src }}"
@@ -60,3 +72,5 @@
     - {src: "bin-x86_64-efi/ipxe.efi", dest: "{{ bootloader_filename }}.efi"}
     - {src: "bin-x86_64-efi/snp.efi", dest: "{{ bootloader_filename }}-snp.efi"}
     - {src: "bin-x86_64-efi/snponly.efi", dest: "{{ bootloader_filename }}-snponly.efi"}
+    - {src: "bin-x86_64-efi/ipxe.efi.dsk", dest: "{{ bootloader_filename }}.efi.dsk"}
+    - {src: "bin-x86_64-efi/snp.efi.dsk", dest: "{{ bootloader_filename }}-snp.efi.dsk"}

--- a/roles/netbootxyz/vars/debian.yml
+++ b/roles/netbootxyz/vars/debian.yml
@@ -15,3 +15,4 @@ netbootxyz_packages:
   - syslinux
   - syslinux-common
   - toilet
+  - mtools

--- a/roles/netbootxyz/vars/ubuntu.yml
+++ b/roles/netbootxyz/vars/ubuntu.yml
@@ -15,6 +15,7 @@ netbootxyz_packages:
   - syslinux
   - syslinux-common
   - toilet
+  - mtools
 
 pipxe_packages:
   - acpica-tools


### PR DESCRIPTION
This adds floppy generation for the DHCP and DHCP-snp EFI boot images.

Some of the systems I have access to support uploading a floppy image to the IPMI interface to boot the server from. The IPMI interface supports booting ISO's, but only via a Samba share, therefore requiring external resources.

As the server itself is EFI-enabled this allows you to boot netboot.xyz in EFI mode without having to make network changes (PXE boot or Samba share) or require physical presence (USB thumbdrive, CD image).