### PR TITLE
Moves win_base_url and rhel_base_url to local-vars.ipxe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.84] - 2024-00-00
 
+## Changed
+
+- Moves win_base_url and rhel_base_url out of boot.cfg to local-vars.ipxe as they are
+  user defined variables.
+
 ## [2.0.83] - 2024-11-07
 
 ## Changed

--- a/roles/netbootxyz/templates/local-vars.ipxe.j2
+++ b/roles/netbootxyz/templates/local-vars.ipxe.j2
@@ -8,3 +8,7 @@
 # Please note that this variable is always read from the local-vars.ipxe onb the tftp server the root DHCP provided
 # If the variable isn't present at runtime, the user will be queried to press a key to boot from the proxy DHCP prtovided ftfp server
 #set use_proxydhcp_settings true
+
+### Media Locations for Licensed Distros
+#set rhel_base_url http://my_rhel_mirror/rhel/
+#set win_base_url http://my_windows_mirror/windows/

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -25,13 +25,6 @@ iseq ${platform} efi && set ipxe_disk netboot.xyz-snponly.efi || set ipxe_disk n
 # set default boot timeout
 set boot_timeout {{ boot_timeout }}
 
-######################################
-# Media Locations for Licensed Distros
-######################################
-
-set rhel_base_url {{ rhel_base_url | default("") }}
-set win_base_url {{ win_base_url | default("") }}
-
 ##################
 # official mirrors
 ##################

--- a/user_overrides.yml
+++ b/user_overrides.yml
@@ -37,10 +37,6 @@ make_num_jobs: 1
 #  supergrub:
 #    enabled: false
 
-# set licensed media locations in boot.cfg
-# win_base_url:
-# rhel_base_url:
-
 early_menu_enabled: false
 early_menu_contents: |
    ### early menu overrides


### PR DESCRIPTION
Moves win_base_url and rhel_base_url to local-vars.ipxe as they are locally defined variables by the user and are not defined for the hosted site.

Prevents override of variables by the loaded boot.cfg.

Closes https://github.com/netbootxyz/netboot.xyz/issues/1344