### PR TITLE
Allow for live_endpoint override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 
 - Moves win_base_url and rhel_base_url out of boot.cfg to local-vars.ipxe as they are
   user defined variables.
+- Adds a check in boot.cfg to see if live_endpoint is set from local-vars.ipxe. This
+  will allow the user to set their overrides locally on their network.
 
 ## [2.0.83] - 2024-11-07
 

--- a/roles/netbootxyz/templates/local-vars.ipxe.j2
+++ b/roles/netbootxyz/templates/local-vars.ipxe.j2
@@ -12,3 +12,6 @@
 ### Media Locations for Licensed Distros
 #set rhel_base_url http://my_rhel_mirror/rhel/
 #set win_base_url http://my_windows_mirror/windows/
+
+### Sets the local live endpoint for the users local installation
+#set live_endpoint http://my_ip_address:8080

--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -10,8 +10,8 @@ set boot_domain {{ boot_domain }}
 # set location of memdisk
 set memdisk {{ memdisk_location }}
 
-# set location of custom netboot.xyz live assets
-set live_endpoint {{ live_endpoint }}
+# set location of custom netboot.xyz live assets, override in local-vars.ipxe
+isset ${live_endpoint} || set live_endpoint {{ live_endpoint }}
 
 # signature check enabled?
 set sigs_enabled {{ sigs_enabled | default(false) | bool | lower }}


### PR DESCRIPTION
Skips setting the live_endpoint from boot.cfg if
its already been loaded from local-vars.ipxe. This will allow overrides to stick and not get overriden.