### PR TITLE
Change the mirror of Tiny Core Linux

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -486,7 +486,7 @@ releases:
   tinycore:
     enabled: true
     menu: linux
-    mirror: http://distro.ibiblio.org/tinycorelinux
+    mirror: http://tinycorelinux.net
     name: Tiny Core Linux
     versions:
     - arch: x86


### PR DESCRIPTION
The ibiblio mirror seems to be down. At the same time the project has its own repository, so we could the mirror URL to that.