### PR TITLE
Sort NixOS releases newest to oldest

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -328,24 +328,24 @@ releases:
     menu: linux
     name: NixOS
     versions:
-    - code_name: nixos-20.09
-      name: nixos-20.09
-    - code_name: nixos-21.05
-      name: nixos-21.05
-    - code_name: nixos-21.11
-      name: nixos-21.11
-    - code_name: nixos-22.05
-      name: nixos-22.05
-    - code_name: nixos-22.11
-      name: nixos-22.11
-    - code_name: nixos-23.05
-      name: nixos-23.05
-    - code_name: nixos-23.11
-      name: nixos-23.11
-    - code_name: nixos-24.05
-      name: nixos-24.05
     - code_name: nixos-24.11
       name: nixos-24.11
+    - code_name: nixos-24.05
+      name: nixos-24.05
+    - code_name: nixos-23.11
+      name: nixos-23.11
+    - code_name: nixos-23.05
+      name: nixos-23.05
+    - code_name: nixos-22.11
+      name: nixos-22.11
+    - code_name: nixos-22.05
+      name: nixos-22.05
+    - code_name: nixos-21.11
+      name: nixos-21.11
+    - code_name: nixos-21.05
+      name: nixos-21.05
+    - code_name: nixos-20.09
+      name: nixos-20.09
     - code_name: nixos-unstable
       name: nixos-unstable
   openEuler:


### PR DESCRIPTION
This means the first version shown is the latest release, which makes more sense.

The nixos-unstable release unfortunately hasn't been rebuilt in years, so I'm not sure if it makes sense to include it. cc @mic92