### PR TITLE
Fix CentOS Stream base_dir

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -176,7 +176,7 @@ releases:
     - code_name: current
       name: current
   centos:
-    base_dir: centos-stream
+    base_dir: null
     enabled: true
     menu: linux
     mirror: https://mirror.stream.centos.org


### PR DESCRIPTION
CentOS Stream repo starts right at the root of the mirror, thus we need to set base_dir to null to be able to boot from it. Otherwise, it navigates to following non-existent url: https://mirror.stream.centos.org/centos-stream/10-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz