### PR TITLE
Add NFS support to the PXE rom

### DIFF
--- a/roles/netbootxyz/files/ipxe/local/general.h
+++ b/roles/netbootxyz/files/ipxe/local/general.h
@@ -2,6 +2,7 @@
 #define CONSOLE_CMD           /* Console command */
 #define DIGEST_CMD            /* Image crypto digest commands */
 #define DOWNLOAD_PROTO_HTTPS  /* Secure Hypertext Transfer Protocol */
+#define DOWNLOAD_PROTO_NFS    /* NFS */
 #define IMAGE_COMBOOT         /* COMBOOT */
 #define IMAGE_TRUST_CMD       /* Image trust management commands */
 #define IMAGE_GZIP            /* GZIP image support */

--- a/roles/netbootxyz/files/ipxe/local/general.h.efi
+++ b/roles/netbootxyz/files/ipxe/local/general.h.efi
@@ -2,6 +2,7 @@
 #define CONSOLE_CMD           /* Console command */
 #define DIGEST_CMD            /* Image crypto digest commands */
 #define DOWNLOAD_PROTO_HTTPS  /* Secure Hypertext Transfer Protocol */
+#define DOWNLOAD_PROTO_NFS    /* NFS */
 #define IMAGE_TRUST_CMD       /* Image trust management commands */
 #define IMAGE_GZIP            /* GZIP image support */
 #define IMAGE_PNG             /* PNG image support */


### PR DESCRIPTION
Fixes #1583

Add NFS support to the PXE rom build

* Add `#define DOWNLOAD_PROTO_NFS` to `roles/netbootxyz/files/ipxe/local/general.h` to enable NFS support
* Add `#define DOWNLOAD_PROTO_NFS` to `roles/netbootxyz/files/ipxe/local/general.h.efi` to enable NFS support

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/netbootxyz/netboot.xyz/pull/1587?shareId=962409a2-d14f-452c-a70d-ea65efa225cb).