### PR TITLE
Update boot.cfg.j2 to use custom ${boot_domain}

### DIFF
--- a/roles/netbootxyz/templates/menu/boot.cfg.j2
+++ b/roles/netbootxyz/templates/menu/boot.cfg.j2
@@ -4,8 +4,8 @@
 # set site name
 set site_name {{ site_name }}
 
-# set boot domain
-set boot_domain {{ boot_domain }}
+# set location of custom boot domain, override in local-vars.ipxe
+isset ${boot_domain} || set boot_domain {{ boot_domain }}
 
 # set location of memdisk
 set memdisk {{ memdisk_location }}


### PR DESCRIPTION
fix local-vars.ipxe can't overwrite ${boot_domain}

details: https://github.com/orgs/netbootxyz/discussions/1451