### PR TITLE
fix(ipxe): fix filename checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ All notable changes to this project will be documented in this file.
 
 - Deepin
 
+### Fixed
+
+- Loading of tftpmenu local-vars.ipxe, HOSTANEM-${hostname}.ipxe,
+  MAC-${mac:hexraw}.ipxe, MAC-${mac:hexhyp}.ipxe and custom menu.ipxe from the
+  root of the tftp server. The root `tftp-root-path` is a variable and can be
+  set in `local-vars.ipxe` to override. The default is `/`.
+
 ## [2.0.87] - 2025-05-08
 
 ### Added

--- a/roles/netbootxyz/templates/disks/netboot.xyz.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz.j2
@@ -15,6 +15,7 @@ set boot_domain {{ boot_domain }}
 set ipxe_version ${version}
 set version {{ boot_version }}
 set conn_type https
+set tftp-root-path /
 
 :start
 echo ${bold}${fg_gre}${site_name} - ${fg_whi}v${version}${boldoff}
@@ -45,6 +46,12 @@ isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}.efi && goto t
 isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}-snp.efi && goto tftpmenu ||
 isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}-snponly.efi && goto tftpmenu ||
 isset ${tftp-server} && iseq ${filename} {{ bootloader_filename }}-arm64.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} ${tftp-root-path}{{ bootloader_filename }}.kpxe && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} ${tftp-root-path}{{ bootloader_filename }}-undionly.kpxe && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} ${tftp-root-path}{{ bootloader_filename }}.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} ${tftp-root-path}{{ bootloader_filename }}-snp.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} ${tftp-root-path}{{ bootloader_filename }}-snponly.efi && goto tftpmenu ||
+isset ${tftp-server} && iseq ${filename} ${tftp-root-path}{{ bootloader_filename }}-arm64.efi && goto tftpmenu ||
 goto menu
 
 :failsafe
@@ -98,7 +105,8 @@ goto menu || goto failsafe
 :tftpmenu
 chain tftp://${tftp-server}/local-vars.ipxe || echo ${VARS_ERR}
 isset ${hostname} && chain --autofree tftp://${tftp-server}/HOSTNAME-${hostname}.ipxe || echo Custom boot by Hostname not found trying MAC...
-chain --autofree tftp://${tftp-server}/MAC-${mac:hexraw}.ipxe || echo Custom boot by MAC not found booting default...
+chain --autofree tftp://${tftp-server}/MAC-${mac:hexraw}.ipxe || echo Custom boot by MAC (hexraw) not found, attempting by MAC (hexhyp)...
+chain --autofree tftp://${tftp-server}/MAC-${mac:hexhyp}.ipxe || echo Custom boot by MAC (hexhyp) not found, booting default...
 chain --autofree tftp://${tftp-server}/menu.ipxe || echo ${TFTP_ERR} && goto menu
 
 :menu


### PR DESCRIPTION
The `filename` contains the full path to the file, usually the netboot assets are in `/` of a tftp server, so the check if its booted from the ipxe assets will always fail. Add an additional check prepended with `/` to allow the check to pass when booted from the root of a tftp server.

Also add loading of MAC- ipxe scripts with hypens in addition to raw, i.e. `MAC-00-11-22-33-44-55.ipxe` or `MAC-001122334455.ipxe`.

Fixes: #1097