### PR TITLE
alpinelinux: use interface autodetection

### DIFF
--- a/roles/netbootxyz/templates/menu/alpinelinux.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/alpinelinux.ipxe.j2
@@ -3,7 +3,7 @@
 # Alpine Linux
 # https://alpinelinux.org
 
-isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}::eth0:none:${dns}
+isset ${dhcp-server} && set ipparam ip=dhcp || set ipparam ip=${ip}::${gateway}:${netmask}::::${dns}
 
 goto ${menu}
 


### PR DESCRIPTION
When there are multiple network cards in a system, eth0 could possible not be the right interface to configure leaving the system unable to boot. Leaving it empty will try to find the first interface which is active. This should also provide a better error message when no active interface is found instead of just exiting into an emergency shell.