### PR TITLE
Fix Ansible INJECT_FACTS_AS_VARS deprecation warnings

### DIFF
--- a/roles/netbootxyz/tasks/generate_checksums.yml
+++ b/roles/netbootxyz/tasks/generate_checksums.yml
@@ -56,7 +56,7 @@
     dest: "{{ netbootxyz_root }}/ipxe/{{ checksums_filename }}"
 
 - name: Generate site name banner for index
-  ansible.builtin.shell: toilet -f standard {{ site_name }} --html | grep span
+  ansible.builtin.shell: toilet -f standard {{ site_name | quote }} --html | grep span
   register: index_title
   when: ansible_facts['os_family'] == "Debian"
 

--- a/roles/netbootxyz/tasks/generate_checksums.yml
+++ b/roles/netbootxyz/tasks/generate_checksums.yml
@@ -58,7 +58,7 @@
 - name: Generate site name banner for index
   ansible.builtin.shell: toilet -f standard {{ site_name }} --html | grep span
   register: index_title
-  when: ansible_os_family == "Debian"
+  when: ansible_facts['os_family'] == "Debian"
 
 - name: Reset bootloader filename to first in list
   ansible.builtin.set_fact:

--- a/roles/netbootxyz/tasks/generate_disks_base.yml
+++ b/roles/netbootxyz/tasks/generate_disks_base.yml
@@ -6,18 +6,18 @@
 - name: Gather variables for each operating system
   ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_version'] | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+    - "{{ ansible_facts['os_family'] | lower }}-{{ ansible_facts['distribution_major_version'] | lower }}.yml"
+    - "{{ ansible_facts['distribution'] | lower }}.yml"
+    - "{{ ansible_facts['os_family'] | lower }}.yml"
 
 - name: Ensure EPEL is enabled
   ansible.builtin.dnf:
     name: epel-release
     state: present
   when:
-    - ansible_distribution == "CentOS"
+    - ansible_facts['distribution'] == "CentOS"
 
 - name: Set var to bootloader of loop
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Summary

Fixes the `INJECT_FACTS_AS_VARS` deprecation warnings emitted during builds by replacing deprecated top-level `ansible_*` fact variables with the `ansible_facts[]` dictionary syntax.

- `generate_disks_base.yml`: `ansible_distribution`, `ansible_os_family`, `ansible_distribution_version`, `ansible_distribution_major_version`
- `generate_checksums.yml`: `ansible_os_family`

The top-level injection of facts as variables is deprecated and will be removed in ansible-core 2.24. Using `ansible_facts['fact_name']` is the forward-compatible replacement.

Example warning being fixed:
```
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated,
top-level facts will not be auto injected after the change.
This feature will be removed from ansible-core version 2.24.
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```
