### PR TITLE
Publish autoexec.ipxe as standalone release asset for Secure Boot

### DIFF
--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -82,42 +82,12 @@ bootloaders:
   - desc: Secure Boot ARM64 USB image
     output_bin: -sb-arm64.img
     type: IMG
-  - desc: Secure Boot ARM64 shim, loads iPXE with built-in NIC drivers
-    output_bin: ipxe-shim.efi
-    type: Secure Boot
-  - desc: Secure Boot ARM64 iPXE, built-in NIC drivers (loaded via shim)
-    output_bin: ipxe.efi
-    type: Secure Boot
-  - desc: Secure Boot ARM64 SNP only, boots from chained device (loaded via shim)
-    output_bin: snponly.efi
-    type: Secure Boot
-  - desc: Secure Boot ARM64 SNP shim, loads SNP-only iPXE
-    output_bin: snponly-shim.efi
-    type: Secure Boot
-  - desc: Secure Boot autoexec.ipxe boot script
-    output_bin: autoexec.ipxe
-    type: Script
   secureboot_x86_64:
   - desc: Secure Boot x86_64 ISO for CD/DVD/Virtual Media
     output_bin: -sb.iso
     type: ISO
   - desc: Secure Boot x86_64 USB image
     output_bin: -sb.img
-    type: IMG
-  - desc: Secure Boot x86_64 shim, loads iPXE with built-in NIC drivers
-    output_bin: ipxe-shim.efi
-    type: Secure Boot
-  - desc: Secure Boot x86_64 iPXE, built-in NIC drivers (loaded via shim)
-    output_bin: ipxe.efi
-    type: Secure Boot
-  - desc: Secure Boot x86_64 SNP only, boots from chained device (loaded via shim)
-    output_bin: snponly.efi
-    type: Secure Boot
-  - desc: Secure Boot x86_64 SNP shim, loads SNP-only iPXE
-    output_bin: snponly-shim.efi
-    type: Secure Boot
-  - desc: Secure Boot autoexec.ipxe boot script
-    output_bin: autoexec.ipxe
     type: Script
   uefi:
   - desc: DHCP EFI boot image file, uses built-in iPXE NIC drivers

--- a/roles/netbootxyz/defaults/main.yml
+++ b/roles/netbootxyz/defaults/main.yml
@@ -88,7 +88,7 @@ bootloaders:
     type: ISO
   - desc: Secure Boot x86_64 USB image
     output_bin: -sb.img
-    type: Script
+    type: IMG
   uefi:
   - desc: DHCP EFI boot image file, uses built-in iPXE NIC drivers
     ipxe_bin: ipxe.efi

--- a/roles/netbootxyz/tasks/generate_checksums.yml
+++ b/roles/netbootxyz/tasks/generate_checksums.yml
@@ -15,41 +15,6 @@
     chdir: "{{ netbootxyz_root }}/ipxe/"
   register: netboot_disks_stat
 
-- name: Register Secure Boot x86_64 bootloaders
-  ansible.builtin.shell: ls {{ netbootxyz_root }}/ipxe/secureboot-x86_64/ 2>/dev/null || true
-  register: secureboot_x86_64_disks
-  when: generate_disks_secureboot | default(false) | bool
-
-- name: Gather Secure Boot x86_64 checksums
-  ansible.builtin.command: sha256sum -b {{ item }}
-  with_items:
-    - "{{ secureboot_x86_64_disks.stdout_lines | default([]) }}"
-  args:
-    chdir: "{{ netbootxyz_root }}/ipxe/secureboot-x86_64/"
-  register: secureboot_x86_64_disks_stat
-  when:
-    - generate_disks_secureboot | default(false) | bool
-    - secureboot_x86_64_disks.stdout_lines | default([]) | length > 0
-
-- name: Register Secure Boot ARM64 bootloaders
-  ansible.builtin.shell: ls {{ netbootxyz_root }}/ipxe/secureboot-arm64/ 2>/dev/null || true
-  register: secureboot_arm64_disks
-  when:
-    - generate_disks_secureboot | default(false) | bool
-    - generate_disks_arm | default(false) | bool
-
-- name: Gather Secure Boot ARM64 checksums
-  ansible.builtin.command: sha256sum -b {{ item }}
-  with_items:
-    - "{{ secureboot_arm64_disks.stdout_lines | default([]) }}"
-  args:
-    chdir: "{{ netbootxyz_root }}/ipxe/secureboot-arm64/"
-  register: secureboot_arm64_disks_stat
-  when:
-    - generate_disks_secureboot | default(false) | bool
-    - generate_disks_arm | default(false) | bool
-    - secureboot_arm64_disks.stdout_lines | default([]) | length > 0
-
 - name: Generate ipxe disk checksums
   ansible.builtin.template:
     src: checksums.txt.j2

--- a/roles/netbootxyz/tasks/generate_disks.yml
+++ b/roles/netbootxyz/tasks/generate_disks.yml
@@ -40,3 +40,10 @@
   when:
     - generate_disks_secureboot | default(false) | bool
     - bootloader_filename == "netboot.xyz"
+
+- name: Remove stale autoexec.ipxe when Secure Boot is disabled
+  ansible.builtin.file:
+    path: "{{ netbootxyz_root }}/ipxe/autoexec.ipxe"
+    state: absent
+  when:
+    - not (generate_disks_secureboot | default(false) | bool)

--- a/roles/netbootxyz/tasks/generate_disks_secureboot.yml
+++ b/roles/netbootxyz/tasks/generate_disks_secureboot.yml
@@ -97,6 +97,20 @@
     chdir: "{{ ipxe_source_dir }}/src"
   when: generate_disks_arm | default(false) | bool
 
+- name: Copy autoexec.ipxe to ipxe root as standalone release asset
+  ansible.builtin.copy:
+    src: "{{ netbootxyz_root }}/ipxe/secureboot-x86_64/autoexec.ipxe"
+    dest: "{{ netbootxyz_root }}/ipxe/autoexec.ipxe"
+    remote_src: true
+
+- name: Remove Secure Boot directories after ISO/USB generation
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ netbootxyz_root }}/ipxe/secureboot-x86_64"
+    - "{{ netbootxyz_root }}/ipxe/secureboot-arm64"
+
 - name: Clean up Secure Boot archive
   ansible.builtin.file:
     path: "{{ item }}"

--- a/roles/netbootxyz/templates/checksums.txt.j2
+++ b/roles/netbootxyz/templates/checksums.txt.j2
@@ -4,21 +4,3 @@
 {% for item in netboot_disks_stat.results %}
 {{ item.stdout }}
 {% endfor %}
-{% if secureboot_x86_64_disks_stat is defined and secureboot_x86_64_disks_stat.results is defined %}
-
-# Secure Boot x86_64 (iPXE {{ ipxe_secureboot_version }})
-{% for item in secureboot_x86_64_disks_stat.results %}
-{% if item.stdout is defined %}
-{{ item.stdout | replace('*', '*secureboot-x86_64/') }}
-{% endif %}
-{% endfor %}
-{% endif %}
-{% if secureboot_arm64_disks_stat is defined and secureboot_arm64_disks_stat.results is defined %}
-
-# Secure Boot ARM64 (iPXE {{ ipxe_secureboot_version }})
-{% for item in secureboot_arm64_disks_stat.results %}
-{% if item.stdout is defined %}
-{{ item.stdout | replace('*', '*secureboot-arm64/') }}
-{% endif %}
-{% endfor %}
-{% endif %}

--- a/roles/netbootxyz/templates/index.html.j2
+++ b/roles/netbootxyz/templates/index.html.j2
@@ -149,11 +149,7 @@ exit
     {% for item in bootloaders.secureboot_x86_64 %}
     <tr>
        <td> {{ item.type }} </td>
-       {% if item.type in ['ISO', 'IMG'] %}
        <td> <a href="ipxe/{{ bootloader_filename }}{{ item.output_bin }}">{{ bootloader_filename }}{{ item.output_bin }}</a> </td>
-       {% else %}
-       <td> <a href="ipxe/secureboot-x86_64/{{ item.output_bin }}">{{ item.output_bin }}</a> </td>
-       {% endif %}
        <td> {{ item.desc }} </td>
     </tr>
     {% endfor %}
@@ -173,11 +169,7 @@ exit
     {% for item in bootloaders.secureboot_arm64 %}
     <tr>
        <td> {{ item.type }} </td>
-       {% if item.type in ['ISO', 'IMG'] %}
        <td> <a href="ipxe/{{ bootloader_filename }}{{ item.output_bin }}">{{ bootloader_filename }}{{ item.output_bin }}</a> </td>
-       {% else %}
-       <td> <a href="ipxe/secureboot-arm64/{{ item.output_bin }}">{{ item.output_bin }}</a> </td>
-       {% endif %}
        <td> {{ item.desc }} </td>
     </tr>
     {% endfor %}

--- a/script/build_release
+++ b/script/build_release
@@ -48,6 +48,16 @@ if ! [[ "${TYPE}" == "rolling" ]]; then
   cp buildout/version.ipxe s3outver/
   mkdir -p githubout
   mv buildout/ipxe/* githubout/
+  # Package Secure Boot directories into tarballs for GitHub release assets
+  # (GitHub releases are flat; subdirectories can't be uploaded directly)
+  if [ -d "githubout/secureboot-x86_64" ]; then
+    tar -czf githubout/secureboot-x86_64.tar.gz -C githubout secureboot-x86_64
+    rm -rf githubout/secureboot-x86_64
+  fi
+  if [ -d "githubout/secureboot-arm64" ]; then
+    tar -czf githubout/secureboot-arm64.tar.gz -C githubout secureboot-arm64
+    rm -rf githubout/secureboot-arm64
+  fi
   cd buildout
   rm -Rf ipxe
   tar -czf menus.tar.gz *

--- a/script/build_release
+++ b/script/build_release
@@ -48,24 +48,6 @@ if ! [[ "${TYPE}" == "rolling" ]]; then
   cp buildout/version.ipxe s3outver/
   mkdir -p githubout
   mv buildout/ipxe/* githubout/
-  # Extract autoexec.ipxe as a standalone release asset for Secure Boot.
-  # The signed iPXE binaries are consumed directly from the upstream iPXE
-  # release (ipxeboot.tar.gz) to preserve provenance; netboot.xyz only
-  # ships the boot script that chains into the menu system.
-  if [[ -f "githubout/secureboot-x86_64/autoexec.ipxe" ]]; then
-    cp githubout/secureboot-x86_64/autoexec.ipxe githubout/autoexec.ipxe
-    cp githubout/secureboot-x86_64/autoexec.ipxe s3out/autoexec.ipxe
-  fi
-  # Remove secureboot directories from githubout since the signed binaries
-  # are not re-distributed as netboot.xyz release assets
-  rm -rf githubout/secureboot-x86_64 githubout/secureboot-arm64
-  # Update checksums: remove stale secureboot-* entries, add autoexec.ipxe
-  if [[ -f githubout/*-sha256-checksums.txt ]]; then
-    sed -i '/secureboot-/d' githubout/*-sha256-checksums.txt
-    if [[ -f githubout/autoexec.ipxe ]]; then
-      (cd githubout && sha256sum autoexec.ipxe >> *-sha256-checksums.txt)
-    fi
-  fi
   cd buildout
   rm -Rf ipxe
   tar -czf menus.tar.gz *

--- a/script/build_release
+++ b/script/build_release
@@ -54,6 +54,7 @@ if ! [[ "${TYPE}" == "rolling" ]]; then
   # ships the boot script that chains into the menu system.
   if [[ -f "githubout/secureboot-x86_64/autoexec.ipxe" ]]; then
     cp githubout/secureboot-x86_64/autoexec.ipxe githubout/autoexec.ipxe
+    cp githubout/secureboot-x86_64/autoexec.ipxe s3out/autoexec.ipxe
   fi
   # Remove secureboot directories from githubout since the signed binaries
   # are not re-distributed as netboot.xyz release assets

--- a/script/build_release
+++ b/script/build_release
@@ -59,6 +59,13 @@ if ! [[ "${TYPE}" == "rolling" ]]; then
   # Remove secureboot directories from githubout since the signed binaries
   # are not re-distributed as netboot.xyz release assets
   rm -rf githubout/secureboot-x86_64 githubout/secureboot-arm64
+  # Update checksums: remove stale secureboot-* entries, add autoexec.ipxe
+  if [[ -f githubout/*-sha256-checksums.txt ]]; then
+    sed -i '/secureboot-/d' githubout/*-sha256-checksums.txt
+    if [[ -f githubout/autoexec.ipxe ]]; then
+      (cd githubout && sha256sum autoexec.ipxe >> *-sha256-checksums.txt)
+    fi
+  fi
   cd buildout
   rm -Rf ipxe
   tar -czf menus.tar.gz *

--- a/script/build_release
+++ b/script/build_release
@@ -48,16 +48,16 @@ if ! [[ "${TYPE}" == "rolling" ]]; then
   cp buildout/version.ipxe s3outver/
   mkdir -p githubout
   mv buildout/ipxe/* githubout/
-  # Package Secure Boot directories into tarballs for GitHub release assets
-  # (GitHub releases are flat; subdirectories can't be uploaded directly)
-  if [ -d "githubout/secureboot-x86_64" ]; then
-    tar -czf githubout/secureboot-x86_64.tar.gz -C githubout secureboot-x86_64
-    rm -rf githubout/secureboot-x86_64
+  # Extract autoexec.ipxe as a standalone release asset for Secure Boot.
+  # The signed iPXE binaries are consumed directly from the upstream iPXE
+  # release (ipxeboot.tar.gz) to preserve provenance; netboot.xyz only
+  # ships the boot script that chains into the menu system.
+  if [[ -f "githubout/secureboot-x86_64/autoexec.ipxe" ]]; then
+    cp githubout/secureboot-x86_64/autoexec.ipxe githubout/autoexec.ipxe
   fi
-  if [ -d "githubout/secureboot-arm64" ]; then
-    tar -czf githubout/secureboot-arm64.tar.gz -C githubout secureboot-arm64
-    rm -rf githubout/secureboot-arm64
-  fi
+  # Remove secureboot directories from githubout since the signed binaries
+  # are not re-distributed as netboot.xyz release assets
+  rm -rf githubout/secureboot-x86_64 githubout/secureboot-arm64
   cd buildout
   rm -Rf ipxe
   tar -czf menus.tar.gz *


### PR DESCRIPTION
## Summary
- Publishes the templated `autoexec.ipxe` as a standalone GitHub release asset for Secure Boot
- Removes the `secureboot-x86_64/` and `secureboot-arm64/` directories from `githubout/` since the signed iPXE binaries should be consumed directly from the upstream [iPXE v2.0.0 release](https://github.com/ipxe/ipxe/releases/tag/v2.0.0) (`ipxeboot.tar.gz`) to preserve provenance
- The `autoexec.ipxe` is architecture-independent (identical for x86_64 and ARM64) and contains the netboot.xyz-specific boot domain, version, and menu chain logic

## Why this approach
The previous approach repackaged the signed iPXE binaries into netboot.xyz tarballs, which:
- Broke the checksums file (references `secureboot-x86_64/` paths that no longer exist after repackaging)
- Obscured the provenance of the Microsoft-signed binaries
- Duplicated artifacts that are already available from a trusted upstream source

By publishing only the `autoexec.ipxe` boot script, netboot.xyz ships only what it's responsible for. Downstream consumers (e.g. `docker-netbootxyz`) fetch `ipxeboot.tar.gz` directly from iPXE releases and pair it with `autoexec.ipxe` from netboot.xyz releases.

## New release asset
```
autoexec.ipxe    # Secure Boot boot script: DHCP, failsafe menu, HTTPS/HTTP chain to boot.netboot.xyz
```

## Downstream
Companion PR for docker-netbootxyz: https://github.com/netbootxyz/docker-netbootxyz/pull/134