### PR TITLE
Add Secure Boot shim support for Devuan and Kali

### DIFF
--- a/roles/netbootxyz/templates/menu/devuan.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/devuan.ipxe.j2
@@ -9,6 +9,7 @@ goto ${menu}
 set os Devuan
 set os_arch ${arch}
 iseq ${os_arch} x86_64 && set os_arch amd64 ||
+iseq ${os_arch} arm64 && set os_arch arm64 ||
 clear devuan_version
 clear older_release
 menu ${os} - ${os_arch}
@@ -71,6 +72,8 @@ initrd ${devuan_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:
 md5sum linux initrd.gz
+iseq ${os_arch} amd64 && shim ${devuan_mirror}/${dir}/bootnetx64.efi ||
+iseq ${os_arch} arm64 && shim ${devuan_mirror}/${dir}/bootnetaa64.efi ||
 boot
 
 :devuan_exit

--- a/roles/netbootxyz/templates/menu/kali.ipxe.j2
+++ b/roles/netbootxyz/templates/menu/kali.ipxe.j2
@@ -37,6 +37,8 @@ initrd ${kali_mirror}/${dir}/initrd.gz
 echo
 echo MD5sums:
 md5sum linux initrd.gz
+iseq ${os_arch} amd64 && shim ${kali_mirror}/${dir}/bootnetx64.efi ||
+iseq ${os_arch} arm64 && shim ${kali_mirror}/${dir}/bootnetaa64.efi ||
 boot
 
 :kali_exit


### PR DESCRIPTION
## Summary

- Adds `shim` command lines to `devuan.ipxe.j2` and `kali.ipxe.j2`, matching the pattern already present in `debian.ipxe.j2`
- Both distros publish `bootnetx64.efi` / `bootnetaa64.efi` as part of their `debian-installer` netboot tree, confirmed on their mirrors
- Also adds the missing `arm64` arch mapping to `devuan.ipxe.j2`

## Changes

| File | Change |
|---|---|
| `devuan.ipxe.j2` | Add `arm64` arch mapping; add `shim` lines for amd64 and arm64 |
| `kali.ipxe.j2` | Add `shim` lines for amd64 and arm64 |

The `shim` command is a no-op when Secure Boot is not active, so these changes are safe for all boot paths.