### PR TITLE
Fix hybrid USB image build failure due to missing mbr.bin

### DIFF
--- a/roles/netbootxyz/tasks/generate_disks_hybrid.yml
+++ b/roles/netbootxyz/tasks/generate_disks_hybrid.yml
@@ -1,5 +1,14 @@
 ---
 
+- name: Symlink syslinux mbr.bin to searchable path
+  ansible.builtin.file:
+    src: /usr/lib/syslinux/mbr/mbr.bin
+    dest: /usr/lib/syslinux/mbr.bin
+    state: link
+  when:
+    - generate_disks_hybrid | default(false) | bool
+    - ansible_facts['os_family'] == "Debian"
+
 - name: Generate hybrid ISO x86_64 image
   ansible.builtin.shell: |
     ./util/genfsimg -o {{ netbootxyz_root }}/ipxe/{{ bootloader_filename }}.iso \

--- a/roles/netbootxyz/tasks/generate_disks_hybrid.yml
+++ b/roles/netbootxyz/tasks/generate_disks_hybrid.yml
@@ -5,6 +5,7 @@
     src: /usr/lib/syslinux/mbr/mbr.bin
     dest: /usr/lib/syslinux/mbr.bin
     state: link
+    force: true
   when:
     - generate_disks_hybrid | default(false) | bool
     - ansible_facts['os_family'] == "Debian"


### PR DESCRIPTION
## Summary

- Upstream iPXE commit [`2c84b686`](https://github.com/ipxe/ipxe/commit/2c84b686bcf6dfa77b82e27aa2df1f3ec30e902e) added partition table support to `util/genfsimg` for USB `.img` generation, which now requires `mbr.bin` from syslinux
- On Ubuntu/Debian, `syslinux-common` installs `mbr.bin` to `/usr/lib/syslinux/mbr/mbr.bin`, but `genfsimg`'s `find_syslinux_file()` only searches `/usr/lib/syslinux/` (not the `mbr/` subdirectory)
- Adds a symlink from `/usr/lib/syslinux/mbr.bin` → `/usr/lib/syslinux/mbr/mbr.bin` before hybrid disk generation so `genfsimg` can locate the file

## Context

The build fails at the "Generate hybrid USB x86_64 image" task with:
```
./util/genfsimg: could not find mbr.bin
```

ISO generation is unaffected since `isolinux.bin` is found via `/usr/lib/ISOLINUX/` which is in the search path. The new `mbr.bin` requirement only applies to `.img` (USB) targets added by the upstream commit.