### PR TITLE
Re-enable automatic rolling releases

### DIFF
--- a/.github/workflows/rolling.yml
+++ b/.github/workflows/rolling.yml
@@ -2,13 +2,12 @@ name: rolling
 
 on:
   workflow_dispatch:
-  # Disabled automatic rolling releases during version updates
-  # push:
-  #   paths:
-  #     - 'endpoints.yml'
-  #     - 'roles/netbootxyz/defaults/main.yml'
-  #   branches:
-  #     - development
+  push:
+    paths:
+      - 'endpoints.yml'
+      - 'roles/netbootxyz/defaults/main.yml'
+    branches:
+      - development
 
 env:
   DISCORD_HOOK_URL: ${{ secrets.DISCORD_HOOK_URL }}


### PR DESCRIPTION
## Summary

- Uncomments the push trigger on the rolling workflow so automatic rolling releases fire when `endpoints.yml` or `roles/netbootxyz/defaults/main.yml` are updated on the `development` branch
- Was previously disabled during version updates