### PR TITLE
fix(bootloader): open NIC after dhcp to avoid iPXE 2.0 network unreachable (#1793)

### DIFF
--- a/roles/netbootxyz/templates/disks/autoexec.ipxe.j2
+++ b/roles/netbootxyz/templates/disks/autoexec.ipxe.j2
@@ -29,6 +29,11 @@ prompt --key m --timeout 4000 Hit the ${bold}m${boldoff} key to open failsafe me
 :dhcp
 echo
 dhcp || goto netconfig
+# iPXE 2.0 can leave the NIC closed after using cached DHCP info, which
+# causes the first network transmit to fail with "Network unreachable".
+# Explicitly open the interface (the "||" keeps the script going even if
+# there is no net0) so the subsequent chainload does not hit that (see #1793).
+ifopen net0 ||
 goto menu
 
 :failsafe

--- a/roles/netbootxyz/templates/disks/netboot.xyz-gce.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz-gce.j2
@@ -18,6 +18,11 @@ prompt --key m --timeout 4000 Hit the ${bold}m${boldoff} key to open failsafe me
 :dhcp
 echo
 dhcp || goto netconfig
+# iPXE 2.0 can leave the NIC closed after using cached DHCP info, which
+# causes the first network transmit to fail with "Network unreachable".
+# Explicitly open the interface (the "||" keeps the script going even if
+# there is no net0) so the subsequent chainload does not hit that (see #1793).
+ifopen net0 ||
 goto menu
 
 :failsafe

--- a/roles/netbootxyz/templates/disks/netboot.xyz-metal.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz-metal.j2
@@ -19,6 +19,11 @@ prompt --key m --timeout 4000 Hit the ${bold}m${boldoff} key to open failsafe me
 :dhcp
 echo
 dhcp || goto netconfig
+# iPXE 2.0 can leave the NIC closed after using cached DHCP info, which
+# causes the first network transmit to fail with "Network unreachable".
+# Explicitly open the interface (the "||" keeps the script going even if
+# there is no net0) so the subsequent chainload does not hit that (see #1793).
+ifopen net0 ||
 goto menu
 
 :failsafe

--- a/roles/netbootxyz/templates/disks/netboot.xyz.j2
+++ b/roles/netbootxyz/templates/disks/netboot.xyz.j2
@@ -25,6 +25,11 @@ prompt --key m --timeout 4000 Hit the ${bold}m${boldoff} key to open failsafe me
 :dhcp
 echo
 dhcp || goto netconfig
+# iPXE 2.0 can leave the NIC closed after using cached DHCP info, which
+# causes the first network transmit to fail with "Network unreachable".
+# Explicitly open the interface (the "||" keeps the script going even if
+# there is no net0) so the subsequent chainload does not hit that (see #1793).
+ifopen net0 ||
 isset ${next-server} && isset ${proxydhcp/next-server} && goto choose-tftp || set tftp-server ${next-server} && goto load-custom-ipxe
 
 :choose-tftp


### PR DESCRIPTION
## What

Add an explicit `ifopen net0` immediately after the DHCP request in all embedded iPXE bootloader scripts, before the first network chainload.

## Why

Fixes #1793. iPXE 1.x boots fine, but iPXE 2.0 can leave the NIC closed after using cached DHCP information, so the first network transmit fails with `-ENETUNREACH` ("Network unreachable") and the machine falls through to local boot ("no bootable device"). The failsafe **Manual network configuration** path works around it because it calls `ifopen` before proceeding.

The embedded bootloader script is byte-for-byte identical between netboot.xyz 2.0.89 (works) and 3.0.3 (fails), and both release branches pin an unpinned `ipxe master`. The regression is therefore the upstream iPXE 1.x -> 2.x upgrade baked into newer releases, not a netboot.xyz menu change.

## Fix

```ipxe
:dhcp
echo
dhcp || goto netconfig
# iPXE 2.0 can leave the NIC closed after using cached DHCP info, which
# causes the first network transmit to fail with "Network unreachable".
# Explicitly open the interface (the "||" keeps the script going even if
# there is no net0) so the subsequent chainload does not hit that (see #1793).
ifopen net0 ||
```

The trailing `||` means this line never aborts the boot script, so it is a no-op on iPXE 1.x and on systems without a `net0` device.

Files changed:
- `roles/netbootxyz/templates/disks/netboot.xyz.j2`
- `roles/netbootxyz/templates/disks/autoexec.ipxe.j2`
- `roles/netbootxyz/templates/disks/netboot.xyz-metal.j2`
- `roles/netbootxyz/templates/disks/netboot.xyz-gce.j2`

## Validation note

The fix is in the embedded bootloader, so it only takes effect in a rebuilt bootloader. The PR build (GitHub Actions) produces the real iPXE 2.x `netboot.xyz.kpxe`; that artifact is the authoritative thing to test against the reporter's/VMs (a local ad-hoc rebuild on my side did not faithfully reproduce the production NIC probing).